### PR TITLE
Add theme filtering functionality

### DIFF
--- a/.woodpecker/.verify-pr.yml
+++ b/.woodpecker/.verify-pr.yml
@@ -3,21 +3,15 @@ steps:
     image: madnificent/ember:4.12.1-node_18
     commands:
       - npm ci
-  lint:js:
+  lint-js:
     image: madnificent/ember:4.12.1-node_18
+    depends_on: [install]
     commands:
       - npm run lint:js
-  lint:hbs:
+  lint-hbs:
     image: madnificent/ember:4.12.1-node_18
+    depends_on: [install]
     commands:
       - npm run lint:hbs
-  lint:dependencies:
-    image: madnificent/ember:4.12.1-node_18
-    commands:
-      - npm run lint:css
-  test:
-    image: madnificent/ember:4.12.1-node_18
-    commands:
-      - npm run test:ember
 when:
-  event: pull_request
+  - event: pull_request

--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -40,6 +40,17 @@
       @end={{this.filterService.filters.plannedStartMax}}
       @updateSelected={{this.updateSelectedDateRange}}
     />
+    <Filters::SelectMultipleFilter
+      @id="theme"
+      @label="Kies één of meer thema's"
+      @options={{this.themeList.options}}
+      @selected={{this.themeList.selected}}
+      @updateSelected={{this.updateSelectedThemes}}
+      @noMatchesMessage="Geen thema's gevonden"
+      @searchField="label"
+      @queryParam="thema"
+      @placeholder="Alle thema's"
+    />
     <Filters::SelectFilter
       @id="status"
       @label="Status agendapunten"
@@ -69,6 +80,7 @@
           @queryParam="bestuursorganen"
           @placeholder="Alle bestuursorganen"
         />
+
       </Accordion>
     </section>
   </div>

--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -33,13 +33,6 @@
       @queryParam="gemeentes+provincies"
       @placeholder="Alle besturen"
     />
-    <Filters::DateRangeFilter
-      @startQueryParam="begin"
-      @endQueryParam="eind"
-      @start={{this.filterService.filters.plannedStartMin}}
-      @end={{this.filterService.filters.plannedStartMax}}
-      @updateSelected={{this.updateSelectedDateRange}}
-    />
     <Filters::SelectMultipleFilter
       @id="theme"
       @label="Kies één of meer thema's"
@@ -50,6 +43,13 @@
       @searchField="label"
       @queryParam="thema"
       @placeholder="Alle thema's"
+    />
+    <Filters::DateRangeFilter
+      @startQueryParam="begin"
+      @endQueryParam="eind"
+      @start={{this.filterService.filters.plannedStartMin}}
+      @end={{this.filterService.filters.plannedStartMax}}
+      @updateSelected={{this.updateSelectedDateRange}}
     />
     <Filters::SelectFilter
       @id="status"

--- a/app/components/filter-sidebar-wrapper.ts
+++ b/app/components/filter-sidebar-wrapper.ts
@@ -33,10 +33,7 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
     return this.governingBodyList.options;
   }
   get showAdvancedFilters() {
-    return (
-      this.filterService.filters.governingBodyClassifications?.length > 0 ||
-      this.filterService.filters.themes?.length > 0
-    );
+    return this.filterService.filters.governingBodyClassifications.length > 0;
   }
 
   get statusOfAgendaItemsOptions() {

--- a/app/components/filter-sidebar-wrapper.ts
+++ b/app/components/filter-sidebar-wrapper.ts
@@ -10,6 +10,7 @@ import type {
 } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
 import type FilterService from 'frontend-burgernabije-besluitendatabank/services/filter-service';
 import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
+import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
 
 interface FilterSidebarWrapperArgs {
   filters: AgendaItemsParams;
@@ -21,16 +22,21 @@ interface FilterSidebarWrapperArgs {
 export default class FilterSidebarWrapper extends Component<FilterSidebarWrapperArgs> {
   @service declare governingBodyList: GoverningBodyListService;
   @service declare governmentList: GovernmentListService;
+  @service declare themeList: ThemeListService;
   @service declare router: RouterService;
   @service declare filterService: FilterService;
 
   /** Data quality modal */
   // @tracked modalOpen = false;
+
   get governigBodyOptions() {
     return this.governingBodyList.options;
   }
   get showAdvancedFilters() {
-    return this.filterService.filters.governingBodyClassifications?.length > 0;
+    return (
+      this.filterService.filters.governingBodyClassifications?.length > 0 ||
+      this.filterService.filters.themes?.length > 0
+    );
   }
 
   get statusOfAgendaItemsOptions() {
@@ -98,6 +104,19 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
     this.filterService.updateFilters({
       plannedStartMin: start,
       plannedStartMax: end,
+    });
+  }
+  @action
+  updateSelectedThemes(
+    newOptions: Array<{
+      label: string;
+      id: string;
+      type: 'concepts';
+    }>,
+  ) {
+    this.themeList.selected = newOptions;
+    this.filterService.updateFilters({
+      themes: newOptions.map((o) => o.id).toString(),
     });
   }
 }

--- a/app/components/filters/select-multiple-filter.ts
+++ b/app/components/filters/select-multiple-filter.ts
@@ -46,6 +46,7 @@ export default class SelectMultipleFilterComponent extends FilterComponent<Signa
       }, {});
 
     const queryParams = selectedOptions.reduce((acc, { label, type }) => {
+      type ??= this.args.queryParam;
       return {
         ...acc,
         ...(type && { [type]: acc[type] ? `${acc[type]}+${label}` : label }),

--- a/app/constants/query-parameter-keys.ts
+++ b/app/constants/query-parameter-keys.ts
@@ -7,6 +7,7 @@ export const QueryParameterKeys = {
   keyword: 'trefwoord',
   dateSort: 'datumsortering',
   status: 'status',
+  themes: 'thema',
 };
 
 export default QueryParameterKeys;

--- a/app/controllers/agenda-items/types.ts
+++ b/app/controllers/agenda-items/types.ts
@@ -11,6 +11,7 @@ export interface AgendaItemsParams {
   dataQualityList: Array<string>;
   dateSort: string;
   status: string;
+  themes: string;
 }
 
 export interface AgendaItemsLoaderArgs {
@@ -26,6 +27,7 @@ export type AgendaItemsQueryArguments = {
   keyword?: string;
   locationIds?: string;
   provinceIds?: string;
+  themeIds?: string;
   plannedStartMin?: string;
   plannedStartMax?: string;
   dateSort?: string;

--- a/app/models/concept-scheme.ts
+++ b/app/models/concept-scheme.ts
@@ -1,0 +1,11 @@
+import Model, { attr, hasMany, type AsyncBelongsTo } from '@ember-data/model';
+
+export default class ConceptSchemeModel extends Model {
+  @attr uri?: string;
+  @attr label?: string;
+
+  @hasMany('concept', { inverse: null, async: true })
+  declare concepts: AsyncBelongsTo<ConceptSchemeModel>;
+  @hasMany('concept', { inverse: null, async: true })
+  declare topConcepts: AsyncBelongsTo<ConceptSchemeModel>;
+}

--- a/app/models/concept.ts
+++ b/app/models/concept.ts
@@ -1,0 +1,12 @@
+import Model, { attr, hasMany, type AsyncHasMany } from '@ember-data/model';
+import type ConceptSchemeModel from './concept-scheme';
+
+export default class ConceptModel extends Model {
+  @attr uri?: string;
+  @attr label?: string;
+
+  @hasMany('concept-scheme', { inverse: null, async: true })
+  declare conceptSchemes: AsyncHasMany<ConceptSchemeModel>;
+  @hasMany('concept-scheme', { inverse: null, async: true })
+  declare topConceptSchemes: AsyncHasMany<ConceptSchemeModel>;
+}

--- a/app/routes/agenda-items/index.ts
+++ b/app/routes/agenda-items/index.ts
@@ -43,6 +43,10 @@ export default class AgendaItemsIndexRoute extends Route {
       as: QueryParameterKeys.status,
       refreshModel: true,
     },
+    themes: {
+      as: QueryParameterKeys.themes,
+      refreshModel: true,
+    },
   };
 
   async model(params: AgendaItemsParams) {

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -24,6 +24,7 @@ export default class FilterService extends Service {
     governingBodyClassifications: '',
     dataQualityList: [],
     status: 'Alles',
+    themes: '',
   };
 
   updateFilters(newFilters: Partial<AgendaItemsParams>) {

--- a/app/services/items-service.ts
+++ b/app/services/items-service.ts
@@ -15,12 +15,14 @@ import type { MuSearchResponse } from 'frontend-burgernabije-besluitendatabank/s
 import type { AgendaItemsParams } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
 import { action } from '@ember/object';
 import type FilterService from './filter-service';
+import type ThemeListService from './theme-list';
 
 export default class ItemsService extends Service {
   @service declare municipalityList: MunicipalityListService;
   @service declare provinceList: ProvinceListService;
   @service declare governingBodyList: GoverningBodyListService;
   @service declare governmentList: GovernmentListService;
+  @service declare themeList: ThemeListService;
   @service declare muSearch: MuSearchService;
   @service declare governingBodyDisabledList: GoverningBodyDisabledList;
   @service declare filterService: FilterService;
@@ -98,6 +100,7 @@ export default class ItemsService extends Service {
     async (page: number, loadMore = false) => {
       if (!this.filters) return;
       const locationIds = await this.fetchLocationIds();
+      const themeIds = this.themeList.selectedIds;
       const governingBodyClassificationIds =
         await this.governingBodyList.getGoverningBodyClassificationIdsFromLabels(
           this.filters.governingBodyClassifications,
@@ -109,6 +112,7 @@ export default class ItemsService extends Service {
             index: 'agenda-items',
             page,
             locationIds,
+            themeIds,
             governingBodyClassificationIds,
             ...this.filters,
           }),
@@ -148,6 +152,7 @@ export default class ItemsService extends Service {
       if (!this.filters) return;
 
       const locationIds = await this.fetchLocationIds();
+      const themeIds = this.themeList.selectedIds;
       const governingBodyClassificationIds =
         await this.governingBodyList.getGoverningBodyClassificationIdsFromLabels(
           this.filters.governingBodyClassifications,
@@ -160,6 +165,7 @@ export default class ItemsService extends Service {
               page,
               size: 1,
               locationIds,
+              themeIds,
               governingBodyClassificationIds,
               ...this.filters,
             }),

--- a/app/services/theme-list.ts
+++ b/app/services/theme-list.ts
@@ -2,7 +2,6 @@ import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type FilterService from './filter-service';
 import type Store from '@ember-data/store';
-import { sortObjectsByLabel } from 'frontend-burgernabije-besluitendatabank/utils/array-utils';
 
 export interface ThemeOption {
   id?: string;
@@ -28,10 +27,11 @@ export default class ThemeListService extends Service {
     const sortedConcepts = await this.store.query('concept', {
       'filter[concept-schemes][:id:]': CONCEPT_SCHEME_ID,
       include: 'concept-schemes',
-      sort: 'label',
+      sort: '-:no-case:label',
+      page: { size: 100 },
     });
 
-    this.options = sortedConcepts.slice().sort(sortObjectsByLabel);
+    this.options = sortedConcepts.slice();
     if (this.filterService.filters.themes) {
       const splitThemes = this.filterService.filters.themes.split('+');
       this.selected = this.options.filter((option) =>
@@ -41,7 +41,7 @@ export default class ThemeListService extends Service {
     return this.options;
   }
   get selectedIds() {
-    return this.selected.map((option) => option.id).toString();
+    return this.selected.map((option) => option.id).join(',');
   }
 }
 

--- a/app/services/theme-list.ts
+++ b/app/services/theme-list.ts
@@ -33,8 +33,9 @@ export default class ThemeListService extends Service {
 
     this.options = sortedConcepts.slice().sort(sortObjectsByLabel);
     if (this.filterService.filters.themes) {
+      const splitThemes = this.filterService.filters.themes.split('+');
       this.selected = this.options.filter((option) =>
-        this.filterService.filters.themes?.includes(option.label),
+        splitThemes.includes(option.label),
       );
     }
     return this.options;

--- a/app/services/theme-list.ts
+++ b/app/services/theme-list.ts
@@ -1,0 +1,51 @@
+import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import type FilterService from './filter-service';
+import type Store from '@ember-data/store';
+import { sortObjectsByLabel } from 'frontend-burgernabije-besluitendatabank/utils/array-utils';
+
+export interface ThemeOption {
+  id?: string;
+  label: string;
+  type: string;
+}
+
+const CONCEPT_SCHEME_ID = '37c887b0-136c-42bd-9292-355d3186efa9';
+
+export default class ThemeListService extends Service {
+  @service declare store: Store;
+  @service declare filterService: FilterService;
+
+  @tracked selected: ThemeOption[] = [];
+  @tracked options: ThemeOption[] = [];
+
+  constructor(...args: []) {
+    super(...args);
+    this.loadOptions();
+  }
+
+  async loadOptions() {
+    const sortedConcepts = await this.store.query('concept', {
+      'filter[concept-schemes][:id:]': CONCEPT_SCHEME_ID,
+      include: 'concept-schemes',
+      sort: 'label',
+    });
+
+    this.options = sortedConcepts.slice().sort(sortObjectsByLabel);
+    if (this.filterService.filters.themes) {
+      this.selected = this.options.filter((option) =>
+        this.filterService.filters.themes?.includes(option.label),
+      );
+    }
+    return this.options;
+  }
+  get selectedIds() {
+    return this.selected.map((option) => option.id).toString();
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'theme-list': ThemeListService;
+  }
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -376,9 +376,10 @@ cursor {
   flex: 1;
 }
 
-#governing-body {
+.ember-basic-dropdown-trigger,
+.ember-power-select-trigger {
   ul {
-    margin: 0 0.6rem;
+    margin: 0 !important;
   }
 }
 

--- a/app/utils/array-utils.ts
+++ b/app/utils/array-utils.ts
@@ -2,5 +2,11 @@ interface WithTitle {
   title: string;
 }
 
+interface WithLabel {
+  label: string;
+}
 export const sortObjectsByTitle = (a: WithTitle, b: WithTitle) =>
   a.title.localeCompare(b.title, undefined, { numeric: true });
+
+export const sortObjectsByLabel = (a: WithLabel, b: WithLabel) =>
+  a.label.localeCompare(b.label, undefined, { numeric: true });

--- a/app/utils/search/agenda-items-query.ts
+++ b/app/utils/search/agenda-items-query.ts
@@ -23,6 +23,7 @@ export function createAgendaItemsQuery({
   locationIds,
   plannedStartMin,
   plannedStartMax,
+  themeIds,
   dateSort,
   governingBodyClassificationIds,
   status,
@@ -40,6 +41,7 @@ export function createAgendaItemsQuery({
       plannedStartMax,
       governingBodyClassificationIds,
       status,
+      themeIds,
     }),
     dataMapping,
   };
@@ -52,6 +54,7 @@ function buildFilters({
   plannedStartMax,
   governingBodyClassificationIds,
   status,
+  themeIds,
 }: Partial<AgendaItemsQueryArguments>): Record<string, string> {
   const filters: Record<string, string> = {
     ':has:search_location_id': 't', // Ensure search_location_id is always present
@@ -63,6 +66,12 @@ function buildFilters({
   }
   if (locationIds) {
     filters[':terms:search_location_id'] = locationIds;
+  }
+  if (themeIds) {
+    filters[':query:themas.uuid'] = themeIds
+      .split(',')
+      .map((id) => `"${id}"`)
+      .join(' OR ');
   }
   if (governingBodyClassificationIds) {
     filters[':terms:search_governing_body_classification_id'] =


### PR DESCRIPTION
# Theme filter

###  Description:
Add  new filter to the search interface (mu-search) of the new Lokaal Beslist front-end for GVT Aalter:

###  Tasks:
Add a theme filter based on the OSLO model definitions.
Ensure  filter is integrated into mu-search and work as expected in the frontend.
Create fake test data for both theme and location filtering, as the harvester currently does not provide this data.


### How to test
`ember s --proxy https://lokaal-beslist.andres-dev.s.redhost.be/ `

Select `algemeen bestuur` in the theme dropdown filter. 
It should give 2 results. 