### PR TITLE
Feature/bnb 880 add frontend distance km filter

### DIFF
--- a/app/components/filter-content.ts
+++ b/app/components/filter-content.ts
@@ -22,9 +22,14 @@ export default class FilterContent extends Component {
   @action
   handleSubmit(event: Event) {
     event.preventDefault();
-
-    const queryParams = { [QueryParameterKeys.keyword]: this.value };
-    this.router.transitionTo({ queryParams });
+    if (!this.value) {
+      this.router.transitionTo(this.router.currentRouteName, {
+        queryParams: { [QueryParameterKeys.keyword]: null },
+      });
+    } else {
+      const queryParams = { [QueryParameterKeys.keyword]: this.value };
+      this.router.transitionTo({ queryParams });
+    }
   }
 
   @action

--- a/app/components/filter-content.ts
+++ b/app/components/filter-content.ts
@@ -22,14 +22,10 @@ export default class FilterContent extends Component {
   @action
   handleSubmit(event: Event) {
     event.preventDefault();
-    if (!this.value) {
-      this.router.transitionTo(this.router.currentRouteName, {
-        queryParams: { [QueryParameterKeys.keyword]: null },
-      });
-    } else {
-      const queryParams = { [QueryParameterKeys.keyword]: this.value };
-      this.router.transitionTo({ queryParams });
-    }
+    const queryParams = {
+      [QueryParameterKeys.keyword]: this.value || null,
+    };
+    this.router.transitionTo(this.router.currentRouteName, { queryParams });
   }
 
   @action

--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -33,15 +33,6 @@
       @queryParam="gemeentes+provincies"
       @placeholder="Alle besturen"
     />
-    {{!-- <Filters::Filter @id="street" @label="Straat">
-      <input
-        id="street-input"
-        value={{this.filterService.filters.street}}
-        class="au-c-input au-c-input--block"
-        placeholder="Typ een straatnaam"
-        {{on "input" this.updateStreet}}
-      />
-    </Filters::Filter> --}}
     <Filters::Address::AdressenSelector @id="address-search" />
     <Filters::SelectFilter
       @id="distance"

--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -33,6 +33,29 @@
       @queryParam="gemeentes+provincies"
       @placeholder="Alle besturen"
     />
+    <Filters::Filter @id="street" @label="Straat">
+      <input
+        id="street-input"
+        value={{this.filterService.filters.street}}
+        class="au-c-input au-c-input--block"
+        placeholder="Typ een straatnaam"
+        {{on "input" this.updateStreet}}
+      />
+    </Filters::Filter>
+    {{#if this.filterService.filters.street}}
+      <Filters::SelectFilter
+        @id="distance"
+        @label="Afstand"
+        @options={{this.distanceList.options}}
+        @selected={{this.distanceList.selected}}
+        @updateSelected={{this.updateDistance}}
+        @queryParam="afstand"
+        @allowClear={{false}}
+        @searchEnabled={{false}}
+        @placeholder="Alle afstanden"
+        @searchField="label"
+      />
+    {{/if}}
     <Filters::SelectMultipleFilter
       @id="theme"
       @label="Kies één of meer thema's"

--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -33,7 +33,7 @@
       @queryParam="gemeentes+provincies"
       @placeholder="Alle besturen"
     />
-    <Filters::Filter @id="street" @label="Straat">
+    {{!-- <Filters::Filter @id="street" @label="Straat">
       <input
         id="street-input"
         value={{this.filterService.filters.street}}
@@ -41,7 +41,8 @@
         placeholder="Typ een straatnaam"
         {{on "input" this.updateStreet}}
       />
-    </Filters::Filter>
+    </Filters::Filter> --}}
+    <Filters::Address::AdressenSelector @id="address-search" />
     <Filters::SelectFilter
       @id="distance"
       @label="Afstand"

--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -42,20 +42,18 @@
         {{on "input" this.updateStreet}}
       />
     </Filters::Filter>
-    {{#if this.filterService.filters.street}}
-      <Filters::SelectFilter
-        @id="distance"
-        @label="Afstand"
-        @options={{this.distanceList.options}}
-        @selected={{this.distanceList.selected}}
-        @updateSelected={{this.updateDistance}}
-        @queryParam="afstand"
-        @allowClear={{false}}
-        @searchEnabled={{false}}
-        @placeholder="Alle afstanden"
-        @searchField="label"
-      />
-    {{/if}}
+    <Filters::SelectFilter
+      @id="distance"
+      @label="Afstand"
+      @options={{this.distanceList.options}}
+      @selected={{this.distanceList.selected}}
+      @updateSelected={{this.updateDistance}}
+      @queryParam="afstand"
+      @allowClear={{false}}
+      @searchEnabled={{false}}
+      @placeholder="Alle afstanden"
+      @searchField="label"
+    />
     <Filters::SelectMultipleFilter
       @id="theme"
       @label="Kies één of meer thema's"

--- a/app/components/filter-sidebar-wrapper.hbs
+++ b/app/components/filter-sidebar-wrapper.hbs
@@ -49,7 +49,7 @@
       @selected={{this.distanceList.selected}}
       @updateSelected={{this.updateDistance}}
       @queryParam="afstand"
-      @allowClear={{false}}
+      @allowClear={{true}}
       @searchEnabled={{false}}
       @placeholder="Alle afstanden"
       @searchField="label"
@@ -79,7 +79,7 @@
       @selected={{this.status}}
       @updateSelected={{this.setStatus}}
       @queryParam="status"
-      @allowClear={{false}}
+      @allowClear={{true}}
       @searchEnabled={{false}}
       @placeholder="Alle agendapunten"
     />

--- a/app/components/filter-sidebar-wrapper.ts
+++ b/app/components/filter-sidebar-wrapper.ts
@@ -37,7 +37,10 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
     return this.governingBodyList.options;
   }
   get showAdvancedFilters() {
-    return this.filterService.filters.governingBodyClassifications.length > 0;
+    return (
+      this.filterService.filters.governingBodyClassifications &&
+      this.filterService.filters.governingBodyClassifications.length > 0
+    );
   }
 
   get statusOfAgendaItemsOptions() {
@@ -46,15 +49,6 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
 
   get hasMunicipalityFilter() {
     return this.args.filters.municipalityLabels.length > 0;
-  }
-
-  private performDebouncedUpdate(value: string) {
-    this.filterService.updateFilters({
-      street: value,
-    });
-
-    const queryParams = { [QueryParameterKeys.street]: value };
-    this.router.transitionTo({ queryParams });
   }
 
   @action
@@ -130,13 +124,25 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
     });
   }
 
+  private updateStreetQueryParam(value: string | null) {
+    const queryParams = {
+      [QueryParameterKeys.street]: value,
+    };
+
+    this.router.transitionTo(this.router.currentRouteName, { queryParams });
+  }
+
+  private performDebouncedUpdate(value: string) {
+    this.filterService.updateFilters({ street: value });
+    this.updateStreetQueryParam(value);
+  }
+
   @action
   updateStreet(event: Event) {
-    const value = (event.target as HTMLInputElement).value;
+    const value = (event.target as HTMLInputElement).value.trim();
+
     if (!value) {
-      this.router.transitionTo(this.router.currentRouteName, {
-        queryParams: { [QueryParameterKeys.street]: null },
-      });
+      this.updateStreetQueryParam(null);
     } else {
       debounceTask(this, 'performDebouncedUpdate', value, DEBOUNCE_DELAY);
     }

--- a/app/components/filter-sidebar-wrapper.ts
+++ b/app/components/filter-sidebar-wrapper.ts
@@ -137,7 +137,13 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
   @action
   updateStreet(event: Event) {
     const value = (event.target as HTMLInputElement).value;
-    debounceTask(this, 'performDebouncedUpdate', value, DEBOUNCE_DELAY);
+    if (!value) {
+      this.router.transitionTo(this.router.currentRouteName, {
+        queryParams: { [QueryParameterKeys.street]: null },
+      });
+    } else {
+      debounceTask(this, 'performDebouncedUpdate', value, DEBOUNCE_DELAY);
+    }
   }
 
   @action

--- a/app/components/filter-sidebar-wrapper.ts
+++ b/app/components/filter-sidebar-wrapper.ts
@@ -14,7 +14,6 @@ import type ThemeListService from 'frontend-burgernabije-besluitendatabank/servi
 import type DistanceListService from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 import type { DistanceOption } from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 import QueryParameterKeys from 'frontend-burgernabije-besluitendatabank/constants/query-parameter-keys';
-import { debounce } from '@ember/runloop';
 import { debounceTask } from 'ember-lifeline';
 
 interface FilterSidebarWrapperArgs {
@@ -45,7 +44,7 @@ export default class FilterSidebarWrapper extends Component<FilterSidebarWrapper
   }
 
   get statusOfAgendaItemsOptions() {
-    return ['Alles', 'Behandeld', 'Niet behandeld'];
+    return ['Behandeld', 'Niet behandeld'];
   }
 
   get hasMunicipalityFilter() {

--- a/app/components/filters/address/adressen-selector.hbs
+++ b/app/components/filters/address/adressen-selector.hbs
@@ -4,11 +4,11 @@
     <PowerSelect
       @selected={{this.selectedAddress}}
       @onChange={{perform this.selectSuggestion}}
-      style="z-index: 10;"
+      class="z-index-10"
       @options={{this.addressSuggestion}}
       @searchEnabled={{true}}
       @searchField="fullAddress"
-      @onKeydown={{(perform this.handleKeydown)}}
+      @onKeydown={{perform this.handleKeydown}}
       @placeholder="Typ een straatnaam"
       @allowClear={{true}}
       as |name|

--- a/app/components/filters/address/adressen-selector.hbs
+++ b/app/components/filters/address/adressen-selector.hbs
@@ -1,0 +1,23 @@
+<div ...attributes>
+  <div class={{if @hasErrors "ember-power-select--error"}}>
+    <AuLabel for="address">Straat</AuLabel>
+    <PowerSelect
+      @selected={{this.selectedAddress}}
+      @onChange={{perform this.selectSuggestion}}
+      style="z-index: 10;"
+      @options={{this.addressSuggestion}}
+      @searchEnabled={{true}}
+      @searchField="fullAddress"
+      @onKeydown={{(perform this.handleKeydown)}}
+      @placeholder="Typ een straatnaam"
+      @allowClear={{true}}
+      as |name|
+    >
+      {{name.fullAddress}}
+    </PowerSelect>
+    {{#each @errors as |error|}}
+      <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+    {{/each}}
+  </div>
+
+</div>

--- a/app/components/filters/address/adressen-selector.js
+++ b/app/components/filters/address/adressen-selector.js
@@ -1,0 +1,110 @@
+import { inject as service } from '@ember/service';
+import { task, restartableTask, timeout } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import QueryParameterKeys from 'frontend-burgernabije-besluitendatabank/constants/query-parameter-keys';
+import FilterComponent from '../filter';
+export default class AddressRegisterSelectorComponent extends FilterComponent {
+  @service addressRegister;
+  @service store;
+
+  @tracked addressSuggestion;
+  @tracked selectedAddress;
+  @tracked addressWithBusNumber;
+  @tracked addressesWithBusNumbers;
+
+  constructor() {
+    super(...arguments);
+
+    this.addressRegister.setup({ endpoint: '/adresses-register' });
+    const address = this.getQueryParam(QueryParameterKeys.street);
+    this.getSelectedAddress.perform(address);
+  }
+
+  @task
+  *getSelectedAddress(address) {
+    this.addressSuggestion = yield this.addressRegister.suggest(address);
+    this.selectedAddress = this.addressSuggestion.find((addressSuggestion) => {
+      if (addressSuggestion.fullAddress === address) {
+        this.addressSuggestion = addressSuggestion;
+        this.selectedAddress = addressSuggestion;
+        return true;
+      }
+    });
+  }
+
+  @task
+  *selectSuggestion(addressSuggestion) {
+    this.selectedAddress = yield addressSuggestion;
+
+    this.updateQueryParams({
+      [QueryParameterKeys.street]: addressSuggestion
+        ? addressSuggestion.fullAddress
+        : undefined,
+    });
+  }
+  @restartableTask
+  *handleKeydown(_, e) {
+    yield timeout(400);
+
+    let text = e.target.value || '';
+    if (text.length > 0) {
+      this.addressSuggestion = yield this.addressRegister.suggest(text);
+    }
+  }
+
+  @action
+  handleAddressChange(data) {
+    const addresses = data?.addresses;
+
+    this.selectedAddress = null;
+    this.addressWithBusNumber = null;
+    this.addressesWithBusNumbers = null;
+    this.resetAddressAttributes();
+
+    if (addresses) {
+      let hasBusNumberData = addresses.length > 1;
+      let firstAddress = addresses[0];
+      this.selectedAddress = firstAddress;
+
+      if (hasBusNumberData) {
+        this.addressesWithBusNumbers = addresses;
+        this.handleBusNumberChange(firstAddress);
+      } else {
+        this.updateAddressAttributes(firstAddress);
+      }
+    }
+  }
+
+  @action
+  handleBusNumberChange(address) {
+    this.addressWithBusNumber = address;
+    this.updateAddressAttributes(address);
+  }
+
+  updateAddressAttributes(address) {
+    this.args.address.setProperties({
+      straatnaam: address.street,
+      huisnummer: address.housenumber,
+      busnummer: address.busNumber,
+      postbus: address.zipCode,
+      gemeentenaam: address.municipality,
+      land: address.country,
+      lat: address.lat,
+      lon: address.lon,
+    });
+  }
+
+  resetAddressAttributes() {
+    this.args.address.setProperties({
+      straatnaam: null,
+      huisnummer: null,
+      busnummer: null,
+      postbus: null,
+      gemeentenaam: null,
+      land: null,
+      lat: null,
+      lon: null,
+    });
+  }
+}

--- a/app/components/filters/select-filter.hbs
+++ b/app/components/filters/select-filter.hbs
@@ -14,6 +14,10 @@
     @searchEnabled={{@searchEnabled}}
     as |value|
   >
-    {{value}}
+    {{#if @searchField}}
+      {{get value @searchField}}
+    {{else}}
+      {{value}}
+    {{/if}}
   </PowerSelect>
 </Filters::Filter>

--- a/app/components/filters/select-filter.ts
+++ b/app/components/filters/select-filter.ts
@@ -11,7 +11,7 @@ interface Signature {
   Args: {
     options: Promise<UnifiedOptions[]>;
     selected: string;
-    updateSelected: (selected?: string) => void;
+    updateSelected: (selected?: string | { label: string; id: string }) => void;
   } & FilterArgs;
 }
 
@@ -21,10 +21,17 @@ export default class SelectFilterComponent extends FilterComponent<Signature> {
   }
 
   @action
-  async selectChange(selectedOption: string) {
-    this.args.updateSelected(selectedOption);
-    this.updateQueryParams({
-      [this.args.queryParam]: selectedOption,
-    });
+  async selectChange(selectedOption: string | { label: string; id: string }) {
+    if (typeof selectedOption === 'string') {
+      this.args.updateSelected(selectedOption);
+      this.updateQueryParams({
+        [this.args.queryParam]: selectedOption,
+      });
+    } else {
+      this.args.updateSelected(selectedOption);
+      this.updateQueryParams({
+        [this.args.queryParam]: selectedOption.id,
+      });
+    }
   }
 }

--- a/app/components/filters/select-filter.ts
+++ b/app/components/filters/select-filter.ts
@@ -21,17 +21,22 @@ export default class SelectFilterComponent extends FilterComponent<Signature> {
   }
 
   @action
-  async selectChange(selectedOption: string | { label: string; id: string }) {
-    if (typeof selectedOption === 'string') {
-      this.args.updateSelected(selectedOption);
-      this.updateQueryParams({
-        [this.args.queryParam]: selectedOption,
-      });
+  async selectChange(
+    selectedOption: string | { label: string; id: string } | null,
+  ) {
+    let value: string | undefined;
+
+    if (selectedOption == null) {
+      value = undefined;
+    } else if (typeof selectedOption === 'string') {
+      value = selectedOption;
     } else {
-      this.args.updateSelected(selectedOption);
-      this.updateQueryParams({
-        [this.args.queryParam]: selectedOption.id,
-      });
+      value = selectedOption.id;
     }
+
+    this.args.updateSelected(selectedOption ?? undefined);
+    return this.updateQueryParams({
+      [this.args.queryParam]: value,
+    });
   }
 }

--- a/app/constants/query-parameter-keys.ts
+++ b/app/constants/query-parameter-keys.ts
@@ -8,6 +8,8 @@ export const QueryParameterKeys = {
   dateSort: 'datumsortering',
   status: 'status',
   themes: 'thema',
+  street: 'straat',
+  distance: 'afstand',
 };
 
 export default QueryParameterKeys;

--- a/app/controllers/agenda-items/types.ts
+++ b/app/controllers/agenda-items/types.ts
@@ -1,5 +1,6 @@
 import type { PageableRequest } from 'frontend-burgernabije-besluitendatabank/services/mu-search';
 import type AgendaItem from 'frontend-burgernabije-besluitendatabank/models/mu-search/agenda-item';
+import type { DistanceOption } from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 
 export interface AgendaItemsParams {
   keyword: string;
@@ -12,6 +13,8 @@ export interface AgendaItemsParams {
   dateSort: string;
   status: string;
   themes: string;
+  street: string;
+  distance?: DistanceOption;
 }
 
 export interface AgendaItemsLoaderArgs {

--- a/app/controllers/agenda-items/types.ts
+++ b/app/controllers/agenda-items/types.ts
@@ -27,15 +27,11 @@ export type AgendaItemsQueryArguments = {
   index: string;
   page: number;
   size?: number;
-  keyword?: string;
   locationIds?: string;
   provinceIds?: string;
   themeIds?: string;
-  plannedStartMin?: string;
-  plannedStartMax?: string;
-  dateSort?: string;
   governingBodyClassificationIds?: string;
-  status: string;
+  filters: AgendaItemsParams;
 };
 
 export type AgendaItemMuSearchEntry = {

--- a/app/routes/agenda-items/index.ts
+++ b/app/routes/agenda-items/index.ts
@@ -47,6 +47,14 @@ export default class AgendaItemsIndexRoute extends Route {
       as: QueryParameterKeys.themes,
       refreshModel: true,
     },
+    street: {
+      as: QueryParameterKeys.street,
+      refreshModel: true,
+    },
+    distance: {
+      as: QueryParameterKeys.distance,
+      refreshModel: true,
+    },
   };
 
   async model(params: AgendaItemsParams) {

--- a/app/services/distance-list.ts
+++ b/app/services/distance-list.ts
@@ -2,15 +2,18 @@ import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type FilterService from './filter-service';
 import type Store from '@ember-data/store';
+import type RouterService from '@ember/routing/router-service';
+import QueryParameterKeys from 'frontend-burgernabije-besluitendatabank/constants/query-parameter-keys';
 
 export interface DistanceOption {
-  id?: string;
+  id: string;
   label: string;
 }
 
 export default class DistanceListService extends Service {
   @service declare store: Store;
   @service declare filterService: FilterService;
+  @service declare router: RouterService;
 
   @tracked selected?: DistanceOption;
   @tracked options: DistanceOption[] = [
@@ -51,9 +54,12 @@ export default class DistanceListService extends Service {
   async loadOptions() {
     if (this.filterService.filters.distance) {
       this.selected = this.options.find(
-        (option) => option.id === this.filterService.filters.distance,
+        (option) =>
+          option.id ===
+          this.router.currentRoute.queryParams[QueryParameterKeys.distance],
       );
     }
+    this.filterService.filters.distance = this.selected;
     return this.options;
   }
 }

--- a/app/services/distance-list.ts
+++ b/app/services/distance-list.ts
@@ -1,0 +1,65 @@
+import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import type FilterService from './filter-service';
+import type Store from '@ember-data/store';
+
+export interface DistanceOption {
+  id?: string;
+  label: string;
+}
+
+export default class DistanceListService extends Service {
+  @service declare store: Store;
+  @service declare filterService: FilterService;
+
+  @tracked selected?: DistanceOption;
+  @tracked options: DistanceOption[] = [
+    {
+      id: '0',
+      label: 'Alle afstanden',
+    },
+    {
+      id: '1',
+      label: '< 3 km',
+    },
+    {
+      id: '2',
+      label: '< 5 km',
+    },
+    {
+      id: '3',
+      label: '< 10 km',
+    },
+    {
+      id: '4',
+      label: '< 15 km',
+    },
+    {
+      id: '5',
+      label: '< 25 km',
+    },
+    {
+      id: '6',
+      label: '< 50 km',
+    },
+  ];
+
+  constructor(...args: []) {
+    super(...args);
+    this.loadOptions();
+  }
+  async loadOptions() {
+    if (this.filterService.filters.distance) {
+      this.selected = this.options.find(
+        (option) => option.id === this.filterService.filters.distance,
+      );
+    }
+    return this.options;
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'distance-list': DistanceListService;
+  }
+}

--- a/app/services/distance-list.ts
+++ b/app/services/distance-list.ts
@@ -45,7 +45,7 @@ export default class DistanceListService extends Service {
       id: '6',
       label: '< 50 km',
     },
-  ];
+  ]; // This data will be replaced with a query to the API
 
   constructor(...args: []) {
     super(...args);

--- a/app/services/distance-list.ts
+++ b/app/services/distance-list.ts
@@ -59,7 +59,6 @@ export default class DistanceListService extends Service {
           this.router.currentRoute.queryParams[QueryParameterKeys.distance],
       );
     }
-    this.filterService.filters.distance = this.selected;
     return this.options;
   }
 }

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -23,7 +23,7 @@ export default class FilterService extends Service {
     dateSort: 'desc' as SortType,
     governingBodyClassifications: '',
     dataQualityList: [],
-    status: 'Alles',
+    status: '',
     themes: '',
     street: '',
     distance: undefined,

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -25,6 +25,8 @@ export default class FilterService extends Service {
     dataQualityList: [],
     status: 'Alles',
     themes: '',
+    street: '',
+    distance: undefined,
   };
 
   updateFilters(newFilters: Partial<AgendaItemsParams>) {

--- a/app/services/items-service.ts
+++ b/app/services/items-service.ts
@@ -114,6 +114,7 @@ export default class ItemsService extends Service {
             locationIds,
             themeIds,
             governingBodyClassificationIds,
+            filters: this.filters,
             ...this.filters,
           }),
         );
@@ -167,7 +168,7 @@ export default class ItemsService extends Service {
               locationIds,
               themeIds,
               governingBodyClassificationIds,
-              ...this.filters,
+              filters: this.filters,
             }),
           );
         this.totalAgendaItems = agendaItems.count ?? 0;

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -396,3 +396,7 @@ cursor {
 .au-c-main-header__title {
   max-width: 100% !important;
 }
+
+.z-index-10 {
+  z-index: 10;
+}

--- a/app/utils/search/agenda-items-query.ts
+++ b/app/utils/search/agenda-items-query.ts
@@ -46,32 +46,31 @@ function buildFilters({
   themeIds,
   filters,
 }: Partial<AgendaItemsQueryArguments>): Record<string, string> {
-  const filterParams: Record<string, string> = {
+  const query: Record<string, string> = {
     ':has:search_location_id': 't', // Ensure search_location_id is always present
   };
 
   if (filters?.plannedStartMin) {
-    filterParams[':query:session_planned_start'] =
+    query[':query:session_planned_start'] =
       `session_planned_start:[${filters?.plannedStartMin} TO ${filters?.plannedStartMax || '*'}]`;
   }
   if (locationIds) {
-    filterParams[':terms:search_location_id'] = locationIds;
+    query[':terms:search_location_id'] = locationIds;
   }
   if (themeIds) {
-    filterParams[':query:themas.uuid'] = themeIds
+    query[':query:themas.uuid'] = themeIds
       .split(',')
       .map((id) => `"${id}"`)
       .join(' OR ');
   }
   if (filters?.street) {
-    filterParams[':query:street.name'] = filters.street;
+    query[':query:street.name'] = filters.street;
   }
   if (filters?.distance) {
-    filterParams[':query:distance.uuid'] =
-      filters.distance.id ?? filters.distance;
+    query[':query:distance.uuid'] = filters.distance.id ?? filters.distance;
   }
   if (governingBodyClassificationIds) {
-    filterParams[':terms:search_governing_body_classification_id'] =
+    query[':terms:search_governing_body_classification_id'] =
       governingBodyClassificationIds;
   }
 
@@ -81,9 +80,9 @@ function buildFilters({
       filters?.keyword === '-description*'
     ) {
       if (filters?.keyword.includes('title')) {
-        filterParams[':has-no:title'] = 't';
+        query[':has-no:title'] = 't';
       } else if (filters?.keyword.includes('description')) {
-        filterParams[':has-no:description'] = 't';
+        query[':has-no:description'] = 't';
       }
     } else {
       const parsedResults = keywordSearch([
@@ -103,21 +102,21 @@ function buildFilters({
         }
       }
       if (buildQuery.length !== 0) {
-        filterParams[':query:search_content'] = buildQuery.join(' AND ');
+        query[':query:search_content'] = buildQuery.join(' AND ');
       } else {
-        filterParams[':fuzzy:search_content'] = filters?.keyword;
+        query[':fuzzy:search_content'] = filters?.keyword;
       }
     }
   }
 
   if (filters?.status === 'Behandeld') {
-    filterParams[':has:session_started_at'] = 't';
+    query[':has:session_started_at'] = 't';
   }
   if (filters?.status === 'Niet behandeld') {
-    filterParams[':has-no:session_started_at'] = 't';
+    query[':has-no:session_started_at'] = 't';
   }
 
-  return filterParams;
+  return query;
 }
 
 const dataMapping: DataMapper<AgendaItemMuSearchEntry, AgendaItem> = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@glimmer/component": "^1.1.2",
         "@glimmer/runtime": "^0.93.1",
         "@glimmer/tracking": "^1.1.2",
+        "@lblod/ember-address-search": "^1.0.0",
         "@release-it-plugins/lerna-changelog": "^7.0.0",
         "@tsconfig/ember": "^3.0.8",
         "@types/ember": "^4.0.11",
@@ -9250,6 +9251,20 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@lblod/ember-address-search": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-address-search/-/ember-address-search-1.0.0.tgz",
+      "integrity": "sha512-dV5H4en6EROLS0fZrRKe7LQ/LwGCtca5TbkFp9huSU8ftpkIPHbQEivJxYyQ81oiaSqCyBuClDEwhuHifQoBxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.9",
+        "decorator-transforms": "^2.2.2"
+      },
+      "peerDependencies": {
+        "ember-source": ">= 4.12.0"
       }
     },
     "node_modules/@lint-todo/utils": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/runtime": "^0.93.1",
     "@glimmer/tracking": "^1.1.2",
+    "@lblod/ember-address-search": "^1.0.0",
     "@release-it-plugins/lerna-changelog": "^7.0.0",
     "@tsconfig/ember": "^3.0.8",
     "@types/ember": "^4.0.11",


### PR DESCRIPTION
## Description
- Add a new filter to the filters of the new Lokaal Beslist front-end for GVT Aalter: Distance filter (in km)
- Add also a street filter to search on a specific street
- Url is updated with the correct selected value

## How to test
- Run this branch with `ember s --proxy https://lokaal-beslist.andres-dev.s.redhost.be/` this command or test in on `https://lokaal-beslist.andres-dev.s.redhost.be/`
- On the left sidebar you should see 2 new filters. 
- You can now fill in a street and a distance.
- The backend is not ready yet. This will be done in another ticket.
