### PR TITLE
BNB-871 | Add the new filters also to the filter route

### DIFF
--- a/app/components/agendapunten/filters-topbar.hbs
+++ b/app/components/agendapunten/filters-topbar.hbs
@@ -11,6 +11,7 @@
       {{! TODO make them reactive with the filters/queryParams }}
       {{#each this.filterValues as |keyValue|}}
         <AuPill
+          id={{keyValue.key}}
           @icon="cross"
           @iconAlignment="right"
           {{on "click" (fn this.removeFilter keyValue.key)}}

--- a/app/components/agendapunten/filters-topbar.ts
+++ b/app/components/agendapunten/filters-topbar.ts
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import type { FiltersAsQueryParams } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
 import type ItemsService from 'frontend-burgernabije-besluitendatabank/services/items-service';
 import type FilterService from 'frontend-burgernabije-besluitendatabank/services/filter-service';
+import QueryParameterKeys from 'frontend-burgernabije-besluitendatabank/constants/query-parameter-keys';
 
 export interface AgendapuntenFiltersTopbarSignature {
   Args: {
@@ -26,6 +27,12 @@ export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFil
   get filterValues() {
     return Object.entries(this.args.filters)
       ?.map(([key, value]) => {
+        if (key == QueryParameterKeys.municipalities) {
+          return {
+            key: null,
+            value: null,
+          };
+        }
         return {
           key,
           value: value,

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -18,9 +18,7 @@ export default class AgendaItemsIndexController extends Controller {
   resetFilters() {
     this.filterService.resetFiltersToInitialView();
     this.router.transitionTo(this.router.currentRouteName, {
-      queryParams: {
-        gemeentes: this.filterService.asQueryParams,
-      },
+      queryParams: this.filterService.asQueryParams,
     });
   }
 

--- a/app/controllers/agenda-items/types.ts
+++ b/app/controllers/agenda-items/types.ts
@@ -12,8 +12,8 @@ export interface AgendaItemsParams {
   dataQualityList: Array<string> | null;
   dateSort: string;
   status: string;
-  themes: string;
-  street: string;
+  themes: string | null;
+  street: string | null;
   distance: DistanceOption | null;
 }
 
@@ -26,7 +26,7 @@ export type FiltersAsQueryParams = {
   trefwoord: string | null;
   datumsortering?: SortType;
   status?: string;
-  thema: string;
+  thema: string | null;
   straat: string | null;
   afstand: string | null;
 };

--- a/app/controllers/agenda-items/types.ts
+++ b/app/controllers/agenda-items/types.ts
@@ -14,7 +14,7 @@ export interface AgendaItemsParams {
   status: string;
   themes: string;
   street: string;
-  distance?: DistanceOption;
+  distance: DistanceOption | null;
 }
 
 export type FiltersAsQueryParams = {
@@ -26,6 +26,9 @@ export type FiltersAsQueryParams = {
   trefwoord: string | null;
   datumsortering?: SortType;
   status?: string;
+  thema: string;
+  straat: string | null;
+  afstand: string | null;
 };
 
 export interface AgendaItemsLoaderArgs {

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -9,11 +9,13 @@ import type GovernmentListService from 'frontend-burgernabije-besluitendatabank/
 import type FilterService from 'frontend-burgernabije-besluitendatabank/services/filter-service';
 import type ItemsService from 'frontend-burgernabije-besluitendatabank/services/items-service';
 import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
+import type DistanceListService from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 
 import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import type { SortType } from './agenda-items/types';
 import type { GoverningBodyOption } from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
+import type { DistanceOption } from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 
 export default class FilterController extends Controller {
   @service declare governingBodyList: GoverningBodyListService;
@@ -22,6 +24,7 @@ export default class FilterController extends Controller {
   @service declare filterService: FilterService;
   @service declare itemsService: ItemsService;
   @service declare themeList: ThemeListService;
+  @service declare distanceList: DistanceListService;
 
   get selectedBestuursorganen() {
     return this.governingBodyList.selected?.map(
@@ -133,6 +136,14 @@ export default class FilterController extends Controller {
   @action
   updateSorting(event: { target: { value: SortType } }) {
     this.filterService.updateFilters({ dateSort: event?.target.value });
+  }
+
+  @action
+  updateDistance(selectedDistance: DistanceOption) {
+    this.distanceList.selected = selectedDistance;
+    this.filterService.updateFilters({
+      distance: selectedDistance,
+    });
   }
 
   @action

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -10,6 +10,8 @@ import type GoverningBodyListService from 'frontend-burgernabije-besluitendataba
 import type GovernmentListService from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import type FilterService from 'frontend-burgernabije-besluitendatabank/services/filter-service';
 import type ItemsService from 'frontend-burgernabije-besluitendatabank/services/items-service';
+import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
+
 import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import type { SortType } from './agenda-items/types';
 import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
@@ -21,6 +23,7 @@ export default class FilterController extends Controller {
   @service declare router: RouterService;
   @service declare filterService: FilterService;
   @service declare itemsService: ItemsService;
+  @service declare themeList: ThemeListService;
 
   @tracked selectedThemas: Array<string> = [];
 
@@ -54,6 +57,19 @@ export default class FilterController extends Controller {
   updateSelectedThemas(selected: { label: string }) {
     console.log({ selected });
     this.itemsService.loadAgendaItems.perform(0, false);
+  }
+  @action
+  updateSelectedThemes(
+    newOptions: Array<{
+      label: string;
+      id: string;
+      type: 'concepts';
+    }>,
+  ) {
+    this.themeList.selected = newOptions;
+    this.filterService.updateFilters({
+      themes: newOptions.map((o) => o.id).toString(),
+    });
   }
 
   @action

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -13,8 +13,6 @@ import type DistanceListService from 'frontend-burgernabije-besluitendatabank/se
 
 import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import type { SortType } from './agenda-items/types';
-import type { GoverningBodyOption } from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
-import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 import type { DistanceOption } from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 
 export default class FilterController extends Controller {
@@ -27,13 +25,11 @@ export default class FilterController extends Controller {
   @service declare distanceList: DistanceListService;
 
   get selectedBestuursorganen() {
-    return this.governingBodyList.selected?.map(
-      (orgaan: GoverningBodyOption) => orgaan.id,
-    );
+    return this.governingBodyList.selected?.map((id: string) => id);
   }
 
   get showAdvancedFilters() {
-    return this.filterService.filters.governingBodyClassifications;
+    return this.filterService.filters.governingBodyClassificationIds;
   }
 
   get hasMunicipalityFilter() {
@@ -106,13 +102,10 @@ export default class FilterController extends Controller {
   }
 
   @action
-  updateSelectedGoverningBodyClassifications(
-    newOptions: Array<GoverningBodyOption>,
-  ) {
-    this.governingBodyList.selected = newOptions;
-    const labels = newOptions.map((o) => o.label);
+  updateSelectedGoverningBodyClassifications(ids: Array<string> | null) {
+    this.governingBodyList.selected = ids;
     this.filterService.updateFilters({
-      governingBodyClassifications: serializeArray(labels),
+      governingBodyClassificationIds: ids,
     });
     this.itemsService.loadAgendaItems.perform(0, false);
   }
@@ -155,7 +148,7 @@ export default class FilterController extends Controller {
 
   @action
   async resetFilters() {
-    this.governingBodyList.selected = [];
+    this.governingBodyList.selected = null;
     this.filterService.resetFiltersToInitialView();
     this.goToAgendaItems();
   }

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -58,8 +58,10 @@ export default class FilterController extends Controller {
   ) {
     this.themeList.selected = newOptions;
     this.filterService.updateFilters({
-      themes: newOptions.map((o) => o.id).toString(),
+      themes:
+        newOptions.length >= 1 ? newOptions.map((o) => o.id).toString() : null,
     });
+    this.itemsService.loadAgendaItems.perform(0, false);
   }
 
   @action

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -3,8 +3,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-import { tracked } from '@glimmer/tracking';
-
 import type RouterService from '@ember/routing/router-service';
 import type GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 import type GovernmentListService from 'frontend-burgernabije-besluitendatabank/services/government-list';
@@ -14,8 +12,8 @@ import type ThemeListService from 'frontend-burgernabije-besluitendatabank/servi
 
 import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import type { SortType } from './agenda-items/types';
-import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 import type { GoverningBodyOption } from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
+import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 
 export default class FilterController extends Controller {
   @service declare governingBodyList: GoverningBodyListService;
@@ -24,8 +22,6 @@ export default class FilterController extends Controller {
   @service declare filterService: FilterService;
   @service declare itemsService: ItemsService;
   @service declare themeList: ThemeListService;
-
-  @tracked selectedThemas: Array<string> = [];
 
   get selectedBestuursorganen() {
     return this.governingBodyList.selected?.map(
@@ -53,11 +49,6 @@ export default class FilterController extends Controller {
     return this.itemsService.totalAgendaItems || 0;
   }
 
-  @action
-  updateSelectedThemas(selected: { label: string }) {
-    console.log({ selected });
-    this.itemsService.loadAgendaItems.perform(0, false);
-  }
   @action
   updateSelectedThemes(
     newOptions: Array<{

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -25,11 +25,11 @@ export default class FilterController extends Controller {
   @service declare distanceList: DistanceListService;
 
   get selectedBestuursorganen() {
-    return this.governingBodyList.selected?.map((id: string) => id);
+    return this.governingBodyList.selected;
   }
 
   get showAdvancedFilters() {
-    return this.filterService.filters.governingBodyClassificationIds;
+    return this.filterService.filters.governingBodyClassifications;
   }
 
   get hasMunicipalityFilter() {
@@ -102,12 +102,22 @@ export default class FilterController extends Controller {
   }
 
   @action
-  updateSelectedGoverningBodyClassifications(ids: Array<string> | null) {
-    this.governingBodyList.selected = ids;
-    this.filterService.updateFilters({
-      governingBodyClassificationIds: ids,
-    });
-    this.itemsService.loadAgendaItems.perform(0, false);
+  updateSelectedGoverningBodyClassifications(
+    newOptions: Array<{
+      label: string;
+      id: string;
+      type: 'governing-body-classifications';
+    }>,
+  ) {
+    this.governingBodyList.selected = newOptions;
+    const governingBodyClassifications = newOptions
+      .map((o) => o.label)
+      .toString();
+    if (governingBodyClassifications != '') {
+      this.filterService.updateFilters({
+        governingBodyClassifications,
+      });
+    }
   }
 
   get startDate() {
@@ -148,7 +158,7 @@ export default class FilterController extends Controller {
 
   @action
   async resetFilters() {
-    this.governingBodyList.selected = null;
+    this.governingBodyList.selected = [];
     this.filterService.resetFiltersToInitialView();
     this.goToAgendaItems();
   }

--- a/app/routes/filter.ts
+++ b/app/routes/filter.ts
@@ -4,20 +4,20 @@ import { service } from '@ember/service';
 
 import type { GoverningBodyOption } from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 import type GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
+import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
 
 export default class FilterRoute extends Route {
   @service declare governingBodyList: GoverningBodyListService;
+  @service declare themeList: ThemeListService;
 
-  model() {
+  async model() {
+    const themaOptions = await this.themeList.loadOptions();
+
     return {
       bestuursorgaanOptions: this.governingBodyList
         .options as Array<GoverningBodyOption>,
       agendaStatusOptions: ['Alles', 'Behandeld', 'Niet behandeld'],
-      themaOptions: [
-        { label: 'Onderwijs' },
-        { label: 'Cultuur' },
-        { label: 'Vrije tijd' },
-      ],
+      themaOptions,
     };
   }
 }

--- a/app/routes/filter.ts
+++ b/app/routes/filter.ts
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
+import type DistanceListService from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 
 import type { GoverningBodyOption } from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 import type GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
@@ -9,15 +10,18 @@ import type ThemeListService from 'frontend-burgernabije-besluitendatabank/servi
 export default class FilterRoute extends Route {
   @service declare governingBodyList: GoverningBodyListService;
   @service declare themeList: ThemeListService;
+  @service declare distanceList: DistanceListService;
 
   async model() {
     const themaOptions = await this.themeList.loadOptions();
+    const distanceOptions = await this.distanceList.loadOptions();
 
     return {
       bestuursorgaanOptions: this.governingBodyList
         .options as Array<GoverningBodyOption>,
       agendaStatusOptions: ['Alles', 'Behandeld', 'Niet behandeld'],
       themaOptions,
+      distanceOptions,
     };
   }
 }

--- a/app/services/distance-list.ts
+++ b/app/services/distance-list.ts
@@ -47,10 +47,6 @@ export default class DistanceListService extends Service {
     },
   ]; // This data will be replaced with a query to the API
 
-  constructor(...args: []) {
-    super(...args);
-    this.loadOptions();
-  }
   async loadOptions() {
     if (this.filterService.filters.distance) {
       this.selected = this.options.find(

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -57,7 +57,7 @@ export default class FilterService extends Service {
       governingBodyClassifications: null,
       dataQualityList: null,
       status: 'Alles',
-      themes: '',
+      themes: null,
       street: null,
       distance: null,
     });
@@ -113,7 +113,6 @@ export default class FilterService extends Service {
     if (queryParams.datumsortering == 'desc') {
       delete queryParams.datumsortering;
     }
-
     return queryParams;
   }
 }

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -26,7 +26,7 @@ export default class FilterService extends Service {
     dataQualityList: [],
     status: '',
     themes: '',
-    street: '',
+    street: null,
     distance: null,
   };
 
@@ -47,7 +47,7 @@ export default class FilterService extends Service {
   }
 
   resetFiltersToInitialView() {
-    this.filters = {
+    this.updateFilters({
       keyword: null,
       municipalityLabels: 'Aalter',
       provinceLabels: null,
@@ -58,9 +58,9 @@ export default class FilterService extends Service {
       dataQualityList: null,
       status: 'Alles',
       themes: '',
-      street: '',
+      street: null,
       distance: null,
-    };
+    });
   }
 
   updateFilterFromQueryParamKey(
@@ -74,7 +74,7 @@ export default class FilterService extends Service {
   getFilterKeyForQueryParamKey(
     key: keyof FiltersAsQueryParams,
   ): keyof AgendaItemsParams {
-    // TODO combine QueryParameterKeys with these, QueryParameterKeys are the starting point
+    // TODO: combine QueryParameterKeys with these, QueryParameterKeys are the starting point
     const mapping = {
       gemeentes: 'municipalityLabels',
       provincies: 'provinceLabels',
@@ -106,7 +106,7 @@ export default class FilterService extends Service {
       straat: null, // this.filters.street TODO: once backend is ok
       afstand: null, // this.filters.distance?.label || null TODO: once backend is ok
     };
-    delete queryParams.gemeentes;
+
     if (queryParams.status == 'Alles') {
       delete queryParams.status;
     }

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -27,7 +27,7 @@ export default class FilterService extends Service {
     status: '',
     themes: '',
     street: '',
-    distance: undefined,
+    distance: null,
   };
 
   updateFilters(newFilters: Partial<AgendaItemsParams>) {
@@ -59,7 +59,7 @@ export default class FilterService extends Service {
       status: 'Alles',
       themes: '',
       street: '',
-      distance: undefined,
+      distance: null,
     };
   }
 
@@ -74,6 +74,7 @@ export default class FilterService extends Service {
   getFilterKeyForQueryParamKey(
     key: keyof FiltersAsQueryParams,
   ): keyof AgendaItemsParams {
+    // TODO combine QueryParameterKeys with these, QueryParameterKeys are the starting point
     const mapping = {
       gemeentes: 'municipalityLabels',
       provincies: 'provinceLabels',
@@ -83,6 +84,9 @@ export default class FilterService extends Service {
       trefwoord: 'keyword',
       datumsortering: 'dateSort',
       status: 'status',
+      thema: 'themes',
+      straat: 'street',
+      afstand: 'distance',
     };
 
     return mapping[key] as keyof AgendaItemsParams;
@@ -98,6 +102,9 @@ export default class FilterService extends Service {
       trefwoord: this.filters.keyword,
       datumsortering: this.filters.dateSort as SortType,
       status: this.filters.status,
+      thema: this.filters.themes,
+      straat: null, // this.filters.street TODO: once backend is ok
+      afstand: null, // this.filters.distance?.label || null TODO: once backend is ok
     };
     delete queryParams.gemeentes;
     if (queryParams.status == 'Alles') {

--- a/app/services/items-service.ts
+++ b/app/services/items-service.ts
@@ -108,7 +108,7 @@ export default class ItemsService extends Service {
     async (page: number, loadMore = false) => {
       if (!this.filters) return;
       const locationIds = await this.fetchLocationIds();
-      const themeIds = this.themeList.selectedIds;
+      const themeIds = this.filterService.asQueryParams.thema || undefined;
       const governingBodyClassificationIds =
         await this.governingBodyList.getGoverningBodyClassificationIdsFromLabels(
           this.filters.governingBodyClassifications,
@@ -161,7 +161,7 @@ export default class ItemsService extends Service {
       if (!this.filters) return;
 
       const locationIds = await this.fetchLocationIds();
-      const themeIds = this.themeList.selectedIds;
+      const themeIds = this.filterService.asQueryParams.thema || undefined;
       const governingBodyClassificationIds =
         await this.governingBodyList.getGoverningBodyClassificationIdsFromLabels(
           this.filters.governingBodyClassifications,

--- a/app/services/theme-list.ts
+++ b/app/services/theme-list.ts
@@ -18,11 +18,6 @@ export default class ThemeListService extends Service {
   @tracked selected: ThemeOption[] = [];
   @tracked options: ThemeOption[] = [];
 
-  constructor(...args: []) {
-    super(...args);
-    this.loadOptions();
-  }
-
   async loadOptions() {
     const sortedConcepts = await this.store.query('concept', {
       'filter[concept-schemes][:id:]': CONCEPT_SCHEME_ID,

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -31,6 +31,17 @@
     @searchField="label"
     @queryParam="thema"
   />
+  <Filters::SelectMultipleFilter
+    @id="theme"
+    @label="Kies één of meer thema's"
+    @options={{this.themeList.options}}
+    @selected={{this.themeList.selected}}
+    @updateSelected={{this.updateSelectedThemes}}
+    @noMatchesMessage="Geen thema's gevonden"
+    @searchField="label"
+    @queryParam="thema"
+    @placeholder="Alle thema's"
+  />
   {{! TODO: the filter is not reactive with the filters }}
   <Filters::DateRangeFilter
     @startQueryParam="begin"

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -21,7 +21,19 @@
     </select>
   </section>
   <AuHr />
-  {{! TODO: add street inputField }}
+  <Filters::Address::AdressenSelector @id="address-search" />
+  <Filters::SelectFilter
+    @id="distance"
+    @label="Afstand"
+    @options={{this.model.distanceOptions}}
+    @selected={{this.distanceList.selected}}
+    @updateSelected={{this.updateDistance}}
+    @queryParam="afstand"
+    @allowClear={{true}}
+    @searchEnabled={{false}}
+    @placeholder="Alle afstanden"
+    @searchField="label"
+  />
   <Filters::SelectMultipleFilter
     @id="theme"
     @label="Kies één of meer thema's"

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -45,7 +45,6 @@
     @queryParam="thema"
     @placeholder="Alle thema's"
   />
-  {{! TODO: the filter is not reactive with the filters }}
   <Filters::DateRangeFilter
     @startQueryParam="begin"
     @endQueryParam="eind"

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -22,15 +22,6 @@
   </section>
   <AuHr />
   {{! TODO: add street inputField }}
-  <Filters::SelectMultipleCheckboxFilter
-    @id="thema"
-    @label="Thema"
-    @options={{this.model.themaOptions}}
-    @selected={{this.selectedThemas}}
-    @updateSelected={{this.updateSelectedThemas}}
-    @searchField="label"
-    @queryParam="thema"
-  />
   <Filters::SelectMultipleFilter
     @id="theme"
     @label="Kies één of meer thema's"

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -36,8 +36,8 @@
   />
   <Filters::SelectMultipleFilter
     @id="theme"
-    @label="Kies één of meer thema's"
-    @options={{this.themeList.options}}
+    @label="Thema"
+    @options={{this.model.themaOptions}}
     @selected={{this.themeList.selected}}
     @updateSelected={{this.updateSelectedThemes}}
     @noMatchesMessage="Geen thema's gevonden"


### PR DESCRIPTION
## Description

The theme, street and distance filter where added but are in the old place, make them available in the filter route.


## How to test

1. Go tot the filters and all three should be available
2. theme 'lokaal bestuur' should return 2 results on Andres dev server
3. Distance can be selected but are not added to the queryparams just  yet, added a todo for this
