### PR TITLE
BNB-891 | Number of results

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context.
+
+## How to test
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+
+## Links to other PR's
+
+- /

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -18,7 +18,7 @@ export default class AgendaItemsIndexController extends Controller {
   resetFilters() {
     this.filterService.resetFiltersToInitialView();
     this.router.transitionTo(this.router.currentRouteName, {
-      queryParams: this.filterService.asQueryParams,
+      queryParams: this.filterService.resetQueryParams,
     });
   }
 

--- a/app/controllers/agenda-items/types.ts
+++ b/app/controllers/agenda-items/types.ts
@@ -8,7 +8,7 @@ export interface AgendaItemsParams {
   provinceLabels: string | null;
   plannedStartMin: string | null;
   plannedStartMax: string | null;
-  governingBodyClassifications: string | null;
+  governingBodyClassificationIds: Array<string>;
   dataQualityList: Array<string> | null;
   dateSort: string;
   status: string;

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -14,6 +14,7 @@ import type DistanceListService from 'frontend-burgernabije-besluitendatabank/se
 import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import type { SortType } from './agenda-items/types';
 import type { DistanceOption } from 'frontend-burgernabije-besluitendatabank/services/distance-list';
+import { formatNumber } from 'frontend-burgernabije-besluitendatabank/helpers/format-number';
 
 export default class FilterController extends Controller {
   @service declare governingBodyList: GoverningBodyListService;
@@ -46,6 +47,22 @@ export default class FilterController extends Controller {
 
   get resultCount() {
     return this.itemsService.totalAgendaItems || 0;
+  }
+
+  get isApplyingFilters() {
+    return this.itemsService.loadAgendaItems.isRunning;
+  }
+
+  get showResultsText() {
+    if (this.resultCount === 0) {
+      return 'Geen resultaten';
+    }
+    if (this.filterService.hasActiveUserFilters) {
+      const countAsString = parseInt(formatNumber([this.resultCount, 0]));
+
+      return `Toon ${countAsString} resultaten`;
+    }
+    return 'Toon resultaten';
   }
 
   @action

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -139,6 +139,6 @@ export default class FilterController extends Controller {
   async resetFilters() {
     this.governingBodyList.selectedIds = [];
     this.filterService.resetFiltersToInitialView();
-    this.goToAgendaItems();
+    this.itemsService.loadAgendaItems.perform(0, false);
   }
 }

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -24,12 +24,8 @@ export default class FilterController extends Controller {
   @service declare themeList: ThemeListService;
   @service declare distanceList: DistanceListService;
 
-  get selectedBestuursorganen() {
-    return this.governingBodyList.selected;
-  }
-
-  get showAdvancedFilters() {
-    return this.filterService.filters.governingBodyClassifications;
+  get selectedBestuursorgaanIds() {
+    return this.filterService.filters.governingBodyClassificationIds;
   }
 
   get hasMunicipalityFilter() {
@@ -95,22 +91,12 @@ export default class FilterController extends Controller {
   }
 
   @action
-  updateSelectedGoverningBodyClassifications(
-    newOptions: Array<{
-      label: string;
-      id: string;
-      type: 'governing-body-classifications';
-    }>,
-  ) {
-    this.governingBodyList.selected = newOptions;
-    const governingBodyClassifications = newOptions
-      .map((o) => o.label)
-      .toString();
-    if (governingBodyClassifications != '') {
-      this.filterService.updateFilters({
-        governingBodyClassifications,
-      });
-    }
+  updateSelectedGoverningBodyClassifications(selectedIds: Array<string>) {
+    this.governingBodyList.selectedIds = selectedIds;
+    this.filterService.updateFilters({
+      governingBodyClassificationIds: selectedIds,
+    });
+    this.itemsService.loadAgendaItems.perform(0, false);
   }
 
   get startDate() {
@@ -151,7 +137,7 @@ export default class FilterController extends Controller {
 
   @action
   async resetFilters() {
-    this.governingBodyList.selected = [];
+    this.governingBodyList.selectedIds = [];
     this.filterService.resetFiltersToInitialView();
     this.goToAgendaItems();
   }

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -11,7 +11,6 @@ import type ItemsService from 'frontend-burgernabije-besluitendatabank/services/
 import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
 import type DistanceListService from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 
-import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import type { SortType } from './agenda-items/types';
 import type { DistanceOption } from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 import { formatNumber } from 'frontend-burgernabije-besluitendatabank/helpers/format-number';
@@ -81,31 +80,6 @@ export default class FilterController extends Controller {
     this.itemsService.loadAgendaItems.perform(0, false);
   }
 
-  @action
-  async updateSelectedGovernment(
-    newOptions: Array<{
-      label: string;
-      id: string;
-      type: LocalGovernmentType;
-    }>,
-  ) {
-    this.governmentList.selected = newOptions;
-    const municipalityLabels = newOptions
-      .filter((o) => o.type === LocalGovernmentType.Municipality)
-      .map((o) => o.label)
-      .toString();
-    const provinceLabels = newOptions
-      .filter((o) => o.type === LocalGovernmentType.Province)
-      .map((o) => o.label)
-      .toString();
-    this.filterService.updateFilters({
-      municipalityLabels,
-      provinceLabels,
-    });
-    this.itemsService.loadAgendaItems.perform(0, false);
-
-    await this.governingBodyList.loadOptions();
-  }
   get selectedMunicipality() {
     return this.filterService.filters.municipalityLabels;
   }

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -53,7 +53,7 @@ export default class FilterController extends Controller {
       return 'Geen resultaten';
     }
     if (this.filterService.hasActiveUserFilters) {
-      const countAsString = parseInt(formatNumber([this.resultCount, 0]));
+      const countAsString = formatNumber([this.resultCount, 0]);
 
       return `Toon ${countAsString} resultaten`;
     }

--- a/app/controllers/sessions/types.ts
+++ b/app/controllers/sessions/types.ts
@@ -7,7 +7,7 @@ export interface SessionsParams {
   plannedStartMin: string;
   plannedStartMax: string;
   keyword: string;
-  governingBodyClassifications: string;
+  governingBodyClassificationIds: Array<string>;
   dataQualityList: Array<string>;
   dateSort: string;
   status: string;

--- a/app/router.ts
+++ b/app/router.ts
@@ -12,7 +12,7 @@ Router.map(function () {
     this.route('session', { path: '/:id/zitting' });
   });
 
-  this.route('filter', { path: 'agenda-items/filters' });
+  this.route('filter', { path: 'filters' });
 
   this.route('sessions', { path: '/zittingen' }, function () {
     this.route('session', { path: '/:session_id' });

--- a/app/routes/agenda-items/index.ts
+++ b/app/routes/agenda-items/index.ts
@@ -59,7 +59,7 @@ export default class AgendaItemsIndexRoute extends Route {
     },
   };
 
-  model(params: AgendaItemsParams) {
+  model(params: Partial<AgendaItemsParams>) {
     this.filterService.updateFilters(params);
     this.itemsService.resetAgendaItems();
     this.itemsService.initialAgendaItems(this.filterService.filters);

--- a/app/routes/filter.ts
+++ b/app/routes/filter.ts
@@ -1,9 +1,11 @@
 import Route from '@ember/routing/route';
 
 import { service } from '@ember/service';
-import type DistanceListService from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 
 import type { GoverningBodyOption } from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
+
+import type DistanceListService from 'frontend-burgernabije-besluitendatabank/services/distance-list';
+import type FilterService from 'frontend-burgernabije-besluitendatabank/services/filter-service';
 import type GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
 
@@ -11,14 +13,17 @@ export default class FilterRoute extends Route {
   @service declare governingBodyList: GoverningBodyListService;
   @service declare themeList: ThemeListService;
   @service declare distanceList: DistanceListService;
+  @service declare filterService: FilterService;
 
   async model() {
     const themaOptions = await this.themeList.loadOptions();
     const distanceOptions = await this.distanceList.loadOptions();
+    const bestuursorgaanOptions =
+      await this.governingBodyList.fetchBestuursorgaanOptions('Aalter'); // TODO: Not sure yet how we are going to FIX this value
 
     return {
-      bestuursorgaanOptions: this.governingBodyList
-        .options as Array<GoverningBodyOption>,
+      bestuursorgaanOptions:
+        bestuursorgaanOptions as Array<GoverningBodyOption>,
       agendaStatusOptions: ['Alles', 'Behandeld', 'Niet behandeld'],
       themaOptions,
       distanceOptions,

--- a/app/routes/sessions/index.ts
+++ b/app/routes/sessions/index.ts
@@ -47,6 +47,5 @@ export default class SessionsIndexRoute extends Route {
   async model(params: AgendaItemsParams) {
     this.itemsService.resetSessions();
     this.filterService.updateFilters(params);
-    this.itemsService.initialSessions(params);
   }
 }

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -9,6 +9,7 @@ import type {
   SortType,
 } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
 import { keywordSearch } from 'frontend-burgernabije-besluitendatabank/helpers/keyword-search';
+import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 
 export default class FilterService extends Service {
   @service declare router: RouterService;
@@ -21,7 +22,7 @@ export default class FilterService extends Service {
     plannedStartMin: null,
     plannedStartMax: null,
     dateSort: 'desc' as SortType,
-    governingBodyClassifications: '',
+    governingBodyClassificationIds: [],
     dataQualityList: [],
     status: '',
     themes: '',
@@ -53,7 +54,7 @@ export default class FilterService extends Service {
       plannedStartMin: null,
       plannedStartMax: null,
       dateSort: 'desc' as SortType,
-      governingBodyClassifications: null,
+      governingBodyClassificationIds: [],
       dataQualityList: null,
       status: 'Alles',
       themes: null,
@@ -96,10 +97,18 @@ export default class FilterService extends Service {
   }
 
   get asQueryParams() {
+    let governingBodyClassificationIds = null;
+
+    if (this.filters.governingBodyClassificationIds.length >= 1) {
+      governingBodyClassificationIds = serializeArray(
+        this.filters.governingBodyClassificationIds,
+      );
+    }
+
     const queryParams: FiltersAsQueryParams = {
       gemeentes: 'Aalter',
       provincies: this.filters.provinceLabels,
-      bestuursorganen: this.filters.governingBodyClassifications,
+      bestuursorganen: governingBodyClassificationIds,
       start: this.filters.plannedStartMin,
       end: this.filters.plannedStartMax,
       trefwoord: this.filters.keyword,

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -130,4 +130,20 @@ export default class FilterService extends Service {
     }
     return queryParams;
   }
+
+  get resetQueryParams() {
+    return {
+      gemeentes: null,
+      provincies: null,
+      bestuursorganen: null,
+      start: null,
+      end: null,
+      trefwoord: null,
+      datumsortering: null,
+      status: null,
+      thema: null,
+      straat: null,
+      afstand: null,
+    };
+  }
 }

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -1,7 +1,6 @@
 import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import type ItemsService from './items-service';
 import type RouterService from '@ember/routing/router-service';
 
 import type {
@@ -13,7 +12,7 @@ import { keywordSearch } from 'frontend-burgernabije-besluitendatabank/helpers/k
 
 export default class FilterService extends Service {
   @service declare router: RouterService;
-  @service declare itemsService: ItemsService;
+
   @tracked keywordAdvancedSearch: { [key: string]: string[] } | null = null;
   @tracked filters: AgendaItemsParams = {
     keyword: null,
@@ -90,6 +89,10 @@ export default class FilterService extends Service {
     };
 
     return mapping[key] as keyof AgendaItemsParams;
+  }
+
+  get hasActiveUserFilters() {
+    return !Object.values(this.asQueryParams).every((param) => !param);
   }
 
   get asQueryParams() {

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -93,7 +93,10 @@ export default class FilterService extends Service {
   }
 
   get hasActiveUserFilters() {
-    return !Object.values(this.asQueryParams).every((param) => !param);
+    const withoutMunicipality = { ...this.asQueryParams };
+    delete withoutMunicipality.gemeentes;
+
+    return !Object.values(withoutMunicipality).every((param) => !param);
   }
 
   get asQueryParams() {

--- a/app/services/governing-body-list.ts
+++ b/app/services/governing-body-list.ts
@@ -120,6 +120,28 @@ export default class GoverningBodyListService extends Service {
     return this.options;
   }
 
+  async fetchBestuursorgaanOptions(
+    gemeenteLabel: string,
+  ): Promise<Array<GoverningBodyOption>> {
+    const municipalityIds =
+      await this.municipalityList.getLocationIdsFromLabels(gemeenteLabel);
+    const governingBodies = await this.store.query('governing-body', {
+      filter: {
+        'administrative-unit': {
+          location: {
+            ':id:': municipalityIds.join(','),
+          },
+        },
+      },
+      include: 'classification',
+    });
+    this.options = this.sortOptions(
+      this.getUniqueGoverningBodies(governingBodies),
+    );
+
+    return this.options;
+  }
+
   sortOptions(options: GoverningBodyOption[]): GoverningBodyOption[] {
     return options.sort((a, b) => a.label.localeCompare(b.label));
   }

--- a/app/services/governing-body-list.ts
+++ b/app/services/governing-body-list.ts
@@ -26,13 +26,8 @@ export default class GoverningBodyListService extends Service {
   @service declare governmentList: GovernmentListService;
   @service declare filterService: FilterService;
 
-  @tracked selected: GoverningBodyOption[] = [];
+  @tracked selectedIds: Array<string> = [];
   @tracked options: GoverningBodyOption[] = [];
-
-  constructor(...args: []) {
-    super(...args);
-    this.loadOptions();
-  }
 
   /**
    * Get the governing body classification ids from the given labels.
@@ -65,8 +60,11 @@ export default class GoverningBodyListService extends Service {
   }
 
   async loadOptions() {
-    const { municipalityLabels, governingBodyClassifications, provinceLabels } =
-      this.filterService.filters;
+    const {
+      municipalityLabels,
+      governingBodyClassificationIds,
+      provinceLabels,
+    } = this.filterService.filters;
     if (
       (municipalityLabels == undefined || municipalityLabels == '') &&
       (provinceLabels == undefined || provinceLabels == '')
@@ -104,18 +102,7 @@ export default class GoverningBodyListService extends Service {
         this.getUniqueGoverningBodies(governingBodies),
       );
     }
-    if (governingBodyClassifications != null) {
-      this.selected = this.options.filter((option) =>
-        governingBodyClassifications.split('+').includes(option.label),
-      );
-      if (this.selected.length == 0) {
-        this.router.transitionTo({
-          queryParams: {
-            bestuursorganen: null,
-          },
-        });
-      }
-    }
+    this.selectedIds = governingBodyClassificationIds;
 
     return this.options;
   }

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -83,7 +83,7 @@
   <AuButton
     @skin="primary"
     @width="block"
-    @disabled={{or (eq this.resultCount 0) this.isApplyingFilters}}
+    @disabled={{this.isApplyingFilters}}
     @loading={{this.isApplyingFilters}}
     @loadingMessage="hidden"
     @hideText={{this.isApplyingFilters}}

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -70,7 +70,7 @@
         @id="governing-body"
         @label="Bestuursorganen"
         @options={{this.model.bestuursorgaanOptions}}
-        @selected={{this.selectedBestuursorganen}}
+        @selected={{this.selectedBestuursorgaanIds}}
         @updateSelected={{this.updateSelectedGoverningBodyClassifications}}
         @searchField="label"
         @queryParam="bestuursorganen"

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -80,9 +80,15 @@
 </div>
 <div class="c-interface__sidebar-submit-buttons">
   <AuHr />
-  <AuButton @skin="primary" @width="block" {{on "click" this.goToAgendaItems}}>
-    Toon
-    {{format-number this.resultCount 0}}
-    resultaten
+  <AuButton
+    @skin="primary"
+    @width="block"
+    @disabled={{or (eq this.resultCount 0) this.isApplyingFilters}}
+    @loading={{this.isApplyingFilters}}
+    @loadingMessage="hidden"
+    @hideText={{this.isApplyingFilters}}
+    {{on "click" this.goToAgendaItems}}
+  >
+    {{this.showResultsText}}
   </AuButton>
 </div>


### PR DESCRIPTION
## Description

The count result should be updated when a filter is updated. 
- When no results the button should be disabled.
- When the user didn't select any other filters than default it should just says toon resultaten
- when there are custom filters applied it should show the count

Also update some of the queryparam issues
- reset
- bestuursorganen

## How to test

1. Open the page and go to the filters
2. Select a status or bestuursorgaan the count should be updated
3. When selecting more than one bestuursorgaan the chance is high that there are no results and the button says geen resultaten (should this not be and OR filter?) 