### PR TITLE
BNB-894 | selected date is shown as one label in topbar

### DIFF
--- a/app/components/agendapunten/filters-topbar.ts
+++ b/app/components/agendapunten/filters-topbar.ts
@@ -28,32 +28,46 @@ export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFil
 
   get filterValues() {
     return Object.entries(this.args.filters)
-      ?.map(([key, value]) => {
-        if (key == QueryParameterKeys.municipalities) {
-          return {
-            key: null,
-            value: null,
-          };
-        }
-        if (key == QueryParameterKeys.distance && value) {
-          const distanceOption = this.distanceList.getSelectedDistance(value);
-          if (distanceOption) {
-            return {
-              key,
-              value: distanceOption.label,
-            };
-          }
-          return {
-            key: null,
-            value: null,
-          };
-        }
-        return {
-          key,
-          value: value,
-        };
-      })
-      .filter((kv) => kv.value && kv.value !== '');
+      ?.map(([key, value]) =>
+        this.getFormattedLabelForFilter(key, value as string | undefined),
+      )
+      .filter((kv) => kv && kv.value && kv.value !== '');
+  }
+
+  getFormattedLabelForFilter(key: string, value?: string) {
+    const labelForFilter = {
+      [QueryParameterKeys.municipalities]: {
+        key: null,
+        value: null,
+      },
+      [QueryParameterKeys.distance]: this.createDistanceFilterLabel(
+        key,
+        value as string | undefined,
+      ),
+    };
+
+    if (Object.keys(labelForFilter).includes(key)) {
+      return labelForFilter[key];
+    }
+
+    return {
+      key,
+      value: value,
+    };
+  }
+
+  createDistanceFilterLabel(key: string, value?: string) {
+    const distanceOption = this.distanceList.getSelectedDistance(value);
+    if (distanceOption && value) {
+      return {
+        key,
+        value: distanceOption.label,
+      };
+    }
+    return {
+      key: null,
+      value: null,
+    };
   }
 
   @action

--- a/app/components/agendapunten/filters-topbar.ts
+++ b/app/components/agendapunten/filters-topbar.ts
@@ -89,12 +89,11 @@ export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFil
   }
 
   createDistanceFilterLabel() {
-    const key = QueryParameterKeys.distance;
     const distanceValue = this.args.filters.afstand || undefined;
     const distanceOption = this.distanceList.getSelectedDistance(distanceValue);
     if (distanceOption && distanceValue) {
       return {
-        key,
+        key: QueryParameterKeys.distance,
         value: distanceOption.label,
       };
     }

--- a/app/components/agendapunten/filters-topbar.ts
+++ b/app/components/agendapunten/filters-topbar.ts
@@ -17,6 +17,8 @@ export interface AgendapuntenFiltersTopbarSignature {
   Element: null;
 }
 
+const PERIOD_KEY = 'periode';
+
 export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFiltersTopbarSignature> {
   @service declare itemsService: ItemsService;
   @service declare filterService: FilterService;
@@ -33,7 +35,6 @@ export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFil
   }
 
   get filterKeys() {
-    console.log(`filter`, this.args.filters);
     const keysOfFilters = Object.keys(this.args.filters);
     const keysWithValue = keysOfFilters.filter((key) => {
       const filterValue = this.args.filters[key as keyof FiltersAsQueryParams];
@@ -50,7 +51,7 @@ export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFil
     if (
       keysOfFilters.includes(QueryParameterKeys.start || QueryParameterKeys.end)
     ) {
-      keysWithValue.push('periode');
+      keysWithValue.push(PERIOD_KEY);
     }
 
     return keysWithValue;
@@ -68,7 +69,7 @@ export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFil
   get keyFormatMapping() {
     return {
       [QueryParameterKeys.distance]: this.createDistanceFilterLabel(),
-      ['periode']: this.createPeriodFilterLabel(),
+      [PERIOD_KEY]: this.createPeriodFilterLabel(),
     };
   }
 
@@ -106,25 +107,40 @@ export default class AgendapuntenFiltersTopbar extends Component<AgendapuntenFil
 
     if (start && end) {
       return {
-        key: 'periode',
+        key: PERIOD_KEY,
         value: `Van ${start} tot ${end}`,
       };
     } else if (start) {
       return {
-        key: 'periode',
+        key: QueryParameterKeys.start,
         value: `Van ${start}`,
       };
     } else if (end) {
       return {
-        key: 'periode',
+        key: QueryParameterKeys.end,
         value: `Tot ${end}`,
       };
     }
   }
 
   @action
-  removeFilter(queryParamKey: keyof FiltersAsQueryParams) {
-    this.filterService.updateFilterFromQueryParamKey(queryParamKey, null);
+  removeFilter(queryParamKey: string) {
+    if (queryParamKey === 'periode') {
+      this.filterService.updateFilterFromQueryParamKey(
+        QueryParameterKeys.start as keyof FiltersAsQueryParams,
+        null,
+      );
+      this.filterService.updateFilterFromQueryParamKey(
+        QueryParameterKeys.end as keyof FiltersAsQueryParams,
+        null,
+      );
+    } else {
+      this.filterService.updateFilterFromQueryParamKey(
+        queryParamKey as keyof FiltersAsQueryParams,
+        null,
+      );
+    }
+
     this.args.onFiltersUpdated?.();
   }
 }

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -88,12 +88,16 @@ export default class FilterService extends Service {
     value: string | string[] | null,
   ) {
     const filterKey = this.getFilterKeyForQueryParamKey(key);
+    if (!filterKey) {
+      return null;
+    }
+
     this.filters[filterKey] = value as string & string[] & null;
   }
 
   getFilterKeyForQueryParamKey(
     key: keyof FiltersAsQueryParams,
-  ): keyof AgendaItemsParams {
+  ): keyof AgendaItemsParams | null {
     // TODO: combine QueryParameterKeys with these, QueryParameterKeys are the starting point
     const mapping = {
       gemeentes: 'municipalityLabels',
@@ -108,6 +112,10 @@ export default class FilterService extends Service {
       straat: 'street',
       afstand: 'distance',
     };
+
+    if (!Object.keys(mapping).includes(key)) {
+      return null;
+    }
 
     return mapping[key] as keyof AgendaItemsParams;
   }


### PR DESCRIPTION
## Description

When filtering on a start AND end or only start , end date it should be shown as a single label in the filter pills (topbar)

## How to test

1. set period to e.g. this week => from to label
2.  only set start => only from
3. only end date =? only to
4. test if these can be removed from the filter-topbar aswell
