### PR TITLE
styling: add class for limit description text on overview

### DIFF
--- a/app/components/agenda-item-card.hbs
+++ b/app/components/agenda-item-card.hbs
@@ -7,7 +7,7 @@
       </AuLink>
     </AuHeading>
     {{#if @item.description}}
-      <p class="au-u-base">{{@item.description}}</p>
+      <p class="au-u-base c-agenda-item-card__content">{{@item.description}}</p>
     {{/if}}
     <div class="au-u-margin-top-tiny au-u-muted">
       {{@item.dateFormatted}}


### PR DESCRIPTION
## Description

The class existed for limiting the description but was gone for some reason

## How to test

If no descriptions add a getter with lorem upsom as i did in this example

<img width="474" height="970" alt="image" src="https://github.com/user-attachments/assets/a2789c98-b310-4fe9-8e3f-9516dda61512" />



