### PR TITLE
feat: show a message in the filters when changed

### DIFF
--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -230,6 +230,20 @@ export default class FilterController extends Controller {
     });
   }
 
+  get hasDivergingFilters() {
+    const initial = Object.entries(this.model.initialQueryParams).filter(
+      (value) => value[1],
+    );
+    const current = Object.entries(this.filterService.asQueryParams).filter(
+      (value) => value[1],
+    );
+
+    if (initial.length !== current.length) {
+      return true;
+    }
+    return false;
+  }
+
   @action
   closeFilters() {
     let routeName = 'agenda-items.index';

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -504,3 +504,15 @@ ol.less-margin {
     touch-action: none;
   }
 }
+
+.warning-values-changed--filters {
+  font-size: smaller;
+  display: flex;
+  justify-content: center;
+  padding: 5px 0;
+  background-color: var(--au-orange-500);
+  color: var(--au-orange-200);
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  font-weight: var(--au-medium);
+}

--- a/app/styles/components/_c-interface.scss
+++ b/app/styles/components/_c-interface.scss
@@ -133,7 +133,6 @@
 }
 
 .c-interface__sidebar-submit-buttons {
-  padding: $au-unit;
   padding-top: 0;
   position: sticky;
   bottom: 0;

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -116,16 +116,23 @@
   </section>
 </div>
 <div class="c-interface__sidebar-submit-buttons">
-  <AuHr />
-  <AuButton
-    @skin="primary"
-    @width="block"
-    @disabled={{or this.isApplyingFilters this.filtersHaveErrors}}
-    @loading={{this.isApplyingFilters}}
-    @loadingMessage="hidden"
-    @hideText={{this.isApplyingFilters}}
-    {{on "click" this.goToAgendaItems}}
-  >
-    {{this.showResultsText}}
-  </AuButton>
+  {{#if this.hasDivergingFilters}}
+    <div class="warning-values-changed--filters">
+      <p>Filters zijn gewijzigd!</p>
+    </div>
+  {{/if}}
+  <div class="au-u-padding">
+    <AuButton
+      @skin="primary"
+      @width="block"
+      @disabled={{or this.isApplyingFilters this.filtersHaveErrors}}
+      @loading={{this.isApplyingFilters}}
+      @loadingMessage="hidden"
+      @hideText={{this.isApplyingFilters}}
+      class=""
+      {{on "click" this.goToAgendaItems}}
+    >
+      {{this.showResultsText}}
+    </AuButton>
+  </div>
 </div>


### PR DESCRIPTION
## Description

Let the user know that there are changes so when closing without "tonen" its its own fault

## How to test

- open the filters
- apply
- open again and change
- do some combinations that think it should trigger the message

<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/da4147f3-2564-49c2-a4a5-92cef2b47072" />

