### PR TITLE
BNB-943 | SDK navigation

### DIFF
--- a/app/components/agenda-item-card.hbs
+++ b/app/components/agenda-item-card.hbs
@@ -2,7 +2,7 @@
   {{! template-lint-disable no-invalid-interactive }}
   <article class="c-agenda-item-card" {{on "click" this.goToAgendaItem}}>
     <AuHeading @level="2" @skin="4">
-      <AuLink @route="agenda-items.agenda-item" @model={{@item.id}} class="link-without-line action-sdk-color">
+      <AuLink class="link-without-line action-sdk-color">
         {{@item.titleResolved}}
       </AuLink>
     </AuHeading>

--- a/app/components/agenda-item-card.ts
+++ b/app/components/agenda-item-card.ts
@@ -18,7 +18,14 @@ export default class AgendaItemCard extends Component<AgendaItemCardSignature> {
 
   @action
   goToAgendaItem() {
-    this.router.transitionTo('agenda-items.agenda-item', this.args.item.id);
+    if (this.mbpEmbed.isConnected) {
+      this.mbpEmbed.openNewEmbed({
+        routeName: 'agenda-items.agenda-item',
+        id: this.args.item.id,
+      });
+    } else {
+      this.router.transitionTo('agenda-items.agenda-item', this.args.item.id);
+    }
   }
 
   get showMunicipality() {

--- a/app/components/mbp-embed/open-in-new-embed.hbs
+++ b/app/components/mbp-embed/open-in-new-embed.hbs
@@ -1,0 +1,3 @@
+<AuLink {{on "click" this.openInNewEmbed}}>
+  {{yield}}
+</AuLink>

--- a/app/components/mbp-embed/open-in-new-embed.ts
+++ b/app/components/mbp-embed/open-in-new-embed.ts
@@ -24,6 +24,10 @@ export default class MbpEmbedOpenInNewEmbed extends Component<MbpEmbedOpenInNewE
         routeName: this.args.routeName,
         id: this.args.id,
       });
+      this.mbpEmbed.openNewEmbed({
+        routeName: this.args.routeName,
+        id: this.args.id,
+      });
     } else {
       this.router.transitionTo(this.args.routeName, this.args.id);
     }

--- a/app/components/mbp-embed/open-in-new-embed.ts
+++ b/app/components/mbp-embed/open-in-new-embed.ts
@@ -24,10 +24,6 @@ export default class MbpEmbedOpenInNewEmbed extends Component<MbpEmbedOpenInNewE
         routeName: this.args.routeName,
         id: this.args.id,
       });
-      this.mbpEmbed.openNewEmbed({
-        routeName: this.args.routeName,
-        id: this.args.id,
-      });
     } else {
       this.router.transitionTo(this.args.routeName, this.args.id);
     }

--- a/app/components/mbp-embed/open-in-new-embed.ts
+++ b/app/components/mbp-embed/open-in-new-embed.ts
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/services/mbp-embed';
+import type RouterService from '@ember/routing/router-service';
+
+export interface MbpEmbedOpenInNewEmbedSignature {
+  Args: {
+    routeName: string;
+    id: string;
+  };
+}
+
+export default class MbpEmbedOpenInNewEmbed extends Component<MbpEmbedOpenInNewEmbedSignature> {
+  @service declare mbpEmbed: MbpEmbedService;
+  @service declare router: RouterService;
+
+  @action
+  openInNewEmbed() {
+    if (this.mbpEmbed.isConnected) {
+      this.mbpEmbed.openNewEmbed({
+        routeName: this.args.routeName,
+        id: this.args.id,
+      });
+    } else {
+      this.router.transitionTo(this.args.routeName, this.args.id);
+    }
+  }
+}

--- a/app/components/mbp-embed/reset-embed-history-and-open-link.hbs
+++ b/app/components/mbp-embed/reset-embed-history-and-open-link.hbs
@@ -1,0 +1,3 @@
+<AuLink {{on "click" this.resetViewsAndOpenLink}}>
+  {{yield}}
+</AuLink>

--- a/app/components/mbp-embed/reset-embed-history-and-open-link.ts
+++ b/app/components/mbp-embed/reset-embed-history-and-open-link.ts
@@ -3,6 +3,8 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
+import { timeout } from 'ember-concurrency';
+
 import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/services/mbp-embed';
 import type RouterService from '@ember/routing/router-service';
 import type { FiltersAsQueryParams } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
@@ -19,9 +21,9 @@ export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpE
   @service declare router: RouterService;
 
   @action
-  resetViewsAndOpenLink() {
+  async resetViewsAndOpenLink() {
     if (this.mbpEmbed.isConnected) {
-      this.openNewEmbedWhenOverviewPage();
+      await this.openNewEmbedWhenOverviewPage();
     } else {
       this.router.transitionTo(this.args.routeName, {
         queryParams: this.args.query,
@@ -29,9 +31,10 @@ export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpE
     }
   }
 
-  openNewEmbedWhenOverviewPage() {
+  async openNewEmbedWhenOverviewPage() {
     for (let view = 0; view < this.mbpEmbed.openViews; view++) {
       this.mbpEmbed.client.navigation.back();
+      await timeout(120);
     }
     this.router.transitionTo(this.args.routeName, {
       queryParams: this.args.query,

--- a/app/components/mbp-embed/reset-embed-history-and-open-link.ts
+++ b/app/components/mbp-embed/reset-embed-history-and-open-link.ts
@@ -19,9 +19,9 @@ export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpE
   @service declare router: RouterService;
 
   @action
-  async resetViewsAndOpenLink() {
+  resetViewsAndOpenLink() {
     if (this.mbpEmbed.isConnected) {
-      await this.openNewEmbedWhenOverviewPage();
+      this.openNewEmbedWhenOverviewPage();
     } else {
       this.router.transitionTo(this.args.routeName, {
         queryParams: this.args.query,
@@ -29,12 +29,13 @@ export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpE
     }
   }
 
-  async openNewEmbedWhenOverviewPage() {
-    for (let view = 0; view < this.mbpEmbed.openViews; view++) {
-      await this.mbpEmbed.client.navigation
-        .back()
-        .catch((e) => alert(JSON.stringify(e)));
-    }
+  openNewEmbedWhenOverviewPage() {
+    const backs = Array.from({ length: this.mbpEmbed.openViews }).map(() =>
+      this.mbpEmbed.client.navigation.back(),
+    );
+    Promise.allSettled(backs).then(() => {
+      alert('done');
+    });
     // this.router.transitionTo(this.args.routeName, {
     //   queryParams: this.args.query,
     // });

--- a/app/components/mbp-embed/reset-embed-history-and-open-link.ts
+++ b/app/components/mbp-embed/reset-embed-history-and-open-link.ts
@@ -40,10 +40,7 @@ export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpE
       });
     } else {
       this.mbpEmbed.client.navigation.back();
-      alert('back');
       this.mbpEmbed.client.navigation.back();
-      alert('back');
-      this.openNewEmbedWhenOverviewPage();
     }
   }
 }

--- a/app/components/mbp-embed/reset-embed-history-and-open-link.ts
+++ b/app/components/mbp-embed/reset-embed-history-and-open-link.ts
@@ -1,0 +1,49 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/services/mbp-embed';
+import type RouterService from '@ember/routing/router-service';
+import type { FiltersAsQueryParams } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
+
+export interface MbpEmbedResetEmbedHistoryAndOpenLinkSignature {
+  Args: {
+    routeName: string;
+    query: Partial<FiltersAsQueryParams>;
+  };
+}
+
+export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpEmbedResetEmbedHistoryAndOpenLinkSignature> {
+  @service declare mbpEmbed: MbpEmbedService;
+  @service declare router: RouterService;
+
+  @action
+  resetViewsAndOpenLink() {
+    if (this.mbpEmbed.isConnected) {
+      this.openNewEmbedWhenOverviewPage();
+    } else {
+      this.router.transitionTo(this.args.routeName, {
+        queryParams: this.args.query,
+      });
+    }
+  }
+
+  openNewEmbedWhenOverviewPage() {
+    alert(window.location.pathname);
+    if (
+      window.location.pathname === '/' ||
+      window.location.pathname === '/zittingen'
+    ) {
+      this.router.transitionTo(this.args.routeName, {
+        queryParams: this.args.query,
+      });
+    } else {
+      this.mbpEmbed.client.navigation.back();
+      alert('back');
+      this.mbpEmbed.client.navigation.back();
+      alert('back');
+      this.openNewEmbedWhenOverviewPage();
+    }
+  }
+}

--- a/app/components/mbp-embed/reset-embed-history-and-open-link.ts
+++ b/app/components/mbp-embed/reset-embed-history-and-open-link.ts
@@ -3,8 +3,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
-import { timeout } from 'ember-concurrency';
-
 import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/services/mbp-embed';
 import type RouterService from '@ember/routing/router-service';
 import type { FiltersAsQueryParams } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
@@ -33,11 +31,12 @@ export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpE
 
   async openNewEmbedWhenOverviewPage() {
     for (let view = 0; view < this.mbpEmbed.openViews; view++) {
-      this.mbpEmbed.client.navigation.back();
-      await timeout(120);
+      await this.mbpEmbed.client.navigation
+        .back()
+        .catch((e) => alert(JSON.stringify(e)));
     }
-    this.router.transitionTo(this.args.routeName, {
-      queryParams: this.args.query,
-    });
+    // this.router.transitionTo(this.args.routeName, {
+    //   queryParams: this.args.query,
+    // });
   }
 }

--- a/app/components/mbp-embed/reset-embed-history-and-open-link.ts
+++ b/app/components/mbp-embed/reset-embed-history-and-open-link.ts
@@ -30,17 +30,11 @@ export default class MbpEmbedResetEmbedHistoryAndOpenLink extends Component<MbpE
   }
 
   openNewEmbedWhenOverviewPage() {
-    alert(window.location.pathname);
-    if (
-      window.location.pathname === '/' ||
-      window.location.pathname === '/zittingen'
-    ) {
-      this.router.transitionTo(this.args.routeName, {
-        queryParams: this.args.query,
-      });
-    } else {
-      this.mbpEmbed.client.navigation.back();
+    for (let view = 0; view < this.mbpEmbed.openViews; view++) {
       this.mbpEmbed.client.navigation.back();
     }
+    this.router.transitionTo(this.args.routeName, {
+      queryParams: this.args.query,
+    });
   }
 }

--- a/app/components/session-item-card.hbs
+++ b/app/components/session-item-card.hbs
@@ -2,7 +2,7 @@
   {{! template-lint-disable no-invalid-interactive }}
   <article class="c-agenda-item-card" {{on "click" this.goToSessionItem}}>
     <AuHeading @level="2" @skin="4">
-      <AuLink @route="sessions.session" @model={{@item.id}} class="link-without-line action-sdk-color">
+      <AuLink class="link-without-line action-sdk-color">
         {{@item.governingBodyClassificationNameResolved}}
         {{@item.dateFormatted}}
       </AuLink>

--- a/app/components/session-item-card.ts
+++ b/app/components/session-item-card.ts
@@ -18,7 +18,14 @@ export default class SessionItemCard extends Component<SessionItemCardSignature>
 
   @action
   goToSessionItem() {
-    this.router.transitionTo('sessions.session', this.args.item.id);
+    if (this.mbpEmbed.isConnected) {
+      this.mbpEmbed.openNewEmbed({
+        routeName: 'sessions.session',
+        id: this.args.item.id,
+      });
+    } else {
+      this.router.transitionTo('sessions.session', this.args.item.id);
+    }
   }
 
   get showMunicipality() {

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -220,7 +220,7 @@ export default class FilterController extends Controller {
   }
 
   @action
-  goToAgendaItems() {
+  goToPreviousOverviewPage() {
     let routeName = 'agenda-items.index';
     if (this.model.previousRoute) {
       routeName = this.model.previousRoute.name;

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -25,6 +25,13 @@ export default class ApplicationRoute extends Route {
 
     this.router.on('routeDidChange', (transition: Transition) => {
       this.mbpEmbed.setRouteTitle(transition);
+
+      if (
+        transition.to?.name === 'agenda-items.index' ||
+        transition.to?.name === 'sessions.index'
+      ) {
+        this.mbpEmbed.openViews = 0;
+      }
     });
   }
 

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -207,6 +207,21 @@ export default class FilterService extends Service {
     return queryParams;
   }
 
+  get asUrlQueryParams(): string {
+    const keyValues = Object.entries(this.asQueryParams).map(([key, value]) => {
+      return { key, value };
+    });
+    const withValues = keyValues.filter((kv) => kv.value);
+    if (withValues.length === 0) {
+      return '';
+    }
+
+    const asUrlParamStrings = withValues.map(
+      ({ key, value }) => `${key}=${value}`,
+    );
+    return '?' + asUrlParamStrings.join('&');
+  }
+
   get resetQueryParams() {
     const params = {
       gemeentes: this.mbpEmbed.municipalityLabel,

--- a/app/services/mbp-embed.ts
+++ b/app/services/mbp-embed.ts
@@ -16,6 +16,7 @@ export default class MbpEmbedService extends Service {
   declare tenant: Tenant;
   declare municipalityLabel?: string;
   declare isConnected: boolean;
+  declare openViews: number;
 
   get clientId() {
     return config.APP.MBP_CLIENT_ID;
@@ -54,6 +55,7 @@ export default class MbpEmbedService extends Service {
     try {
       await this.client.connect();
       this.isConnected = true;
+      this.openViews = 0;
       this.client.ui.setStatusLoading(false);
     } catch (e) {
       this.isConnected = false;
@@ -126,6 +128,7 @@ export default class MbpEmbedService extends Service {
         );
       }
       const queryParams = this.filterService.asUrlQueryParams;
+      this.openViews++;
       this.client.navigation.openNewEmbed(`${data.url}${queryParams}`);
     }
   }

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -246,14 +246,14 @@
                     {{#if (eq agendaItem.id this.model.agendaItem.id)}}
                       <p class="au-u-medium">Huidige agendapunt</p>
                     {{else}}
-                      <AuLink
-                        @route="agenda-items.agenda-item"
-                        @model={{agendaItem.id}}
+                      <MbpEmbed::OpenInNewEmbed
+                        @id={{agendaItem.id}}
+                        @routeName="agenda-items.agenda-item"
                       >
                         <p class="truncate">
                           {{agendaItem.titleFormatted}}
                         </p>
-                      </AuLink>
+                      </MbpEmbed::OpenInNewEmbed>
                     {{/if}}
                   </li>
                 {{/each}}
@@ -312,14 +312,14 @@
                 <ol class="less-margin">
                   {{#each similarAgendaItems as |agendaItem|}}
                     <li class="au-u-margin-top-small">
-                      <AuLink
-                        @model={{agendaItem.id}}
-                        @route="agenda-items.agenda-item"
+                      <MbpEmbed::OpenInNewEmbed
+                        @id={{agendaItem.id}}
+                        @routeName="agenda-items.agenda-item"
                       >
                         <p class="truncate">
                           {{agendaItem.titleFormatted}}
                         </p>
-                      </AuLink>
+                      </MbpEmbed::OpenInNewEmbed>
                     </li>
                   {{/each}}
                 </ol>

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -124,7 +124,7 @@
     @loading={{this.isApplyingFilters}}
     @loadingMessage="hidden"
     @hideText={{this.isApplyingFilters}}
-    {{on "click" this.goToAgendaItems}}
+    {{on "click" this.goToPreviousOverviewPage}}
   >
     {{this.showResultsText}}
   </AuButton>

--- a/app/templates/sessions/session.hbs
+++ b/app/templates/sessions/session.hbs
@@ -148,15 +148,15 @@
             <ol type="1" class="less-margin">
               {{#each this.governingBodies as |govBody|}}
                 <Item class="au-u-flex au-u-margin-bottom-small">
-                  <AuLink
-                    @route="sessions.index"
+                  <MbpEmbed::ResetEmbedHistoryAndOpenLink
+                    @routeName="sessions.index"
                     @query={{hash
                       bestuursorganen=govBody.id
                       gemeentes=@model.session.municipality
                     }}
                   >
                     {{govBody.label}}
-                  </AuLink>
+                  </MbpEmbed::ResetEmbedHistoryAndOpenLink>
                 </Item>
               {{/each}}
             </ol>

--- a/app/templates/sessions/session.hbs
+++ b/app/templates/sessions/session.hbs
@@ -70,8 +70,12 @@
             <ol type="1" class="less-margin">
               {{#each this.agendaItems as |item|}}
                 <Item class="au-u-flex au-u-margin-bottom-small">
-                  <AuLink @route="agenda-items.agenda-item" @model={{item.id}}>
-                    {{item.titleFormatted}}</AuLink>
+                  <MbpEmbed::OpenInNewEmbed
+                    @id={{item.id}}
+                    @routeName="agenda-items.agenda-item"
+                  >
+                    {{item.titleFormatted}}
+                  </MbpEmbed::OpenInNewEmbed>
                 </Item>
               {{else}}
                 <AuAlert
@@ -109,11 +113,12 @@
               <ol type="1" class="less-margin">
                 {{#each this.otherSessions.sessions as |otherSessions|}}
                   <Item class="au-u-flex au-u-margin-bottom-small">
-                    <AuLink
-                      @route="sessions.session"
-                      @model={{otherSessions.id}}
+                    <MbpEmbed::OpenInNewEmbed
+                      @id={{otherSessions.id}}
+                      @routeName="sessions.session"
                     >
-                      {{otherSessions.dateFormatted}}</AuLink>
+                      {{otherSessions.dateFormatted}}
+                    </MbpEmbed::OpenInNewEmbed>
                   </Item>
                 {{/each}}
               </ol>

--- a/tests/integration/components/mbp-embed/open-in-new-embed-test.ts
+++ b/tests/integration/components/mbp-embed/open-in-new-embed-test.ts
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | mbp-embed/open-in-new-embed',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<MbpEmbed::OpenInNewEmbed />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`
+      <MbpEmbed::OpenInNewEmbed>
+        template block text
+      </MbpEmbed::OpenInNewEmbed>
+    `);
+
+      assert.dom().hasText('template block text');
+    });
+  },
+);

--- a/tests/integration/components/mbp-embed/reset-embed-history-and-open-link-test.ts
+++ b/tests/integration/components/mbp-embed/reset-embed-history-and-open-link-test.ts
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-burgernabije-besluitendatabank/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | mbp-embed/reset-embed-history-and-open-link',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<MbpEmbed::ResetEmbedHistoryAndOpenLink />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`
+      <MbpEmbed::ResetEmbedHistoryAndOpenLink>
+        template block text
+      </MbpEmbed::ResetEmbedHistoryAndOpenLink>
+    `);
+
+      assert.dom().hasText('template block text');
+    });
+  },
+);


### PR DESCRIPTION
## Description

We want the app to work as easy with the device navigation as possible. This means when going back it does not open the overview page of mbp itself but will go back to that detail page before or to the overview page.

## How to test

- Work with your device navigation to go back and see if everything is intuitive enough
- filter page will always be shown in the overview embed itself. This means that when pressing back on filter page will bring you back to the mbp overview

