### PR TITLE
Feature/bnb 981 no results on overview but in filters

### DIFF
--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -27,14 +27,13 @@ export default class AgendaItemsIndexController extends Controller {
 
   @action
   resetFilters() {
-    this.governingBodyList.selectedIds = [];
     this.address.selectedAddress = undefined;
     this.distanceList.selected = null;
     if (this.mbpEmbed.isLoggedInAsVlaanderen) {
       this.governmentList.selected = [];
     }
     this.filterService.resetFiltersToInitialView();
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0);
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: this.filterService.resetQueryParams,
     });
@@ -47,7 +46,7 @@ export default class AgendaItemsIndexController extends Controller {
 
   @action
   refreshRoute() {
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0);
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: this.filterService.asQueryParams,
     });

--- a/app/controllers/agenda-items/index.ts
+++ b/app/controllers/agenda-items/index.ts
@@ -33,7 +33,7 @@ export default class AgendaItemsIndexController extends Controller {
       this.governmentList.selected = [];
     }
     this.filterService.resetFiltersToInitialView();
-    this.itemsService.fetchItems.perform(0);
+    this.itemsService.currentPage = 0;
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: this.filterService.resetQueryParams,
     });

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -109,7 +109,7 @@ export default class FilterController extends Controller {
     this.filterService.updateFilters({
       themeIds: selected.map((theme) => theme.id),
     });
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 
   get status() {
@@ -119,7 +119,7 @@ export default class FilterController extends Controller {
   @action
   setStatus(value: string) {
     this.filterService.updateFilters({ status: value });
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 
   @action
@@ -128,7 +128,7 @@ export default class FilterController extends Controller {
     this.filterService.updateFilters({
       governingBodyClassificationIds: selectedIds,
     });
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 
   @action
@@ -154,7 +154,7 @@ export default class FilterController extends Controller {
 
     await this.governingBodyList.loadOptions();
     await this.setBestuursorgaanOptions();
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 
   get startDate() {
@@ -175,7 +175,7 @@ export default class FilterController extends Controller {
       plannedStartMin: start,
       plannedStartMax: end,
     });
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 
   @action
@@ -189,7 +189,7 @@ export default class FilterController extends Controller {
       keyword,
     });
     this.filterService.searchOnTitleOnly(onlyOnTitle);
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 
   @action
@@ -198,7 +198,7 @@ export default class FilterController extends Controller {
     this.filterService.updateFilters({
       distance: selectedDistance?.id,
     });
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 
   async setBestuursorgaanOptions() {
@@ -220,7 +220,7 @@ export default class FilterController extends Controller {
   }
 
   @action
-  goToAgendaItems() {
+  goToOverview() {
     let routeName = 'agenda-items.index';
     if (this.model.previousRoute) {
       routeName = this.model.previousRoute.name;
@@ -249,6 +249,6 @@ export default class FilterController extends Controller {
     this.distanceList.selected = null;
     this.governmentList.selected = [];
     this.filterService.resetFiltersToInitialView();
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0, { size: 1 });
   }
 }

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -21,6 +21,7 @@ import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/servic
 
 import { LocalGovernmentType } from 'frontend-burgernabije-besluitendatabank/services/government-list';
 import { formatNumber } from 'frontend-burgernabije-besluitendatabank/helpers/format-number';
+import { deserializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 
 export default class FilterController extends Controller {
   @service declare governingBodyList: GoverningBodyListService;
@@ -38,7 +39,7 @@ export default class FilterController extends Controller {
   @tracked dateRangeHasErrors = false;
 
   get selectedBestuursorgaanIds() {
-    return this.governingBodyList.selectedIds;
+    return this.filterService.filters.governingBodyClassificationIds;
   }
 
   get themaOptions() {
@@ -112,8 +113,13 @@ export default class FilterController extends Controller {
   }
 
   @action
-  updateSelectedGoverningBodyClassifications(selectedIds: Array<string>) {
-    this.governingBodyList.selectedIds = selectedIds;
+  updateSelectedGoverningBodyClassifications(selected: Array<string>) {
+    const selectedIds: Array<string> = [];
+    selected
+      .map((idsString) => {
+        selectedIds.push(...deserializeArray(idsString, ','));
+      })
+      .flat();
     this.filterService.updateFilters({
       governingBodyClassificationIds: selectedIds,
     });
@@ -214,7 +220,6 @@ export default class FilterController extends Controller {
 
   @action
   async resetFilters() {
-    this.governingBodyList.selectedIds = [];
     this.address.selectedAddress = undefined;
     this.distanceList.selected = null;
     this.governmentList.selected = [];

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -121,7 +121,6 @@ export default class FilterController extends Controller {
 
   @action
   updateSelectedGoverningBodyClassifications(selected: Array<string>) {
-    console.log(`selected ids`, selected);
     const selectedIds: Array<string> = [];
     selected
       .map((idsString) => {
@@ -209,7 +208,6 @@ export default class FilterController extends Controller {
     if (this.model.previousRoute) {
       routeName = this.model.previousRoute.name;
     }
-    this.itemsService.currentPage = 0;
     this.router.transitionTo(routeName, {
       queryParams: this.filterService.asQueryParams,
     });

--- a/app/controllers/filter.ts
+++ b/app/controllers/filter.ts
@@ -39,7 +39,14 @@ export default class FilterController extends Controller {
   @tracked dateRangeHasErrors = false;
 
   get selectedBestuursorgaanIds() {
-    return this.filterService.filters.governingBodyClassificationIds;
+    return this.governingBodyList.options
+      .filter(
+        (o) =>
+          this.filterService.filters.governingBodyClassificationIds.filter(
+            (id) => new RegExp('\\b' + id + '\\b').test(o.id),
+          ).length >= 1,
+      )
+      .map((o) => o.id);
   }
 
   get themaOptions() {
@@ -114,6 +121,7 @@ export default class FilterController extends Controller {
 
   @action
   updateSelectedGoverningBodyClassifications(selected: Array<string>) {
+    console.log(`selected ids`, selected);
     const selectedIds: Array<string> = [];
     selected
       .map((idsString) => {

--- a/app/controllers/sessions/index.ts
+++ b/app/controllers/sessions/index.ts
@@ -33,7 +33,7 @@ export default class SessionsIndexController extends Controller {
       this.governmentList.selected = [];
     }
     this.filterService.resetFiltersToInitialView();
-    this.itemsService.fetchItems.perform(0);
+    this.itemsService.currentPage = 0;
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: this.filterService.resetQueryParams,
     });

--- a/app/controllers/sessions/index.ts
+++ b/app/controllers/sessions/index.ts
@@ -27,14 +27,13 @@ export default class SessionsIndexController extends Controller {
 
   @action
   resetFilters() {
-    this.governingBodyList.selectedIds = [];
     this.address.selectedAddress = undefined;
     this.distanceList.selected = null;
     if (this.mbpEmbed.isLoggedInAsVlaanderen) {
       this.governmentList.selected = [];
     }
     this.filterService.resetFiltersToInitialView();
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0);
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: this.filterService.resetQueryParams,
     });
@@ -47,7 +46,7 @@ export default class SessionsIndexController extends Controller {
 
   @action
   refreshRoute() {
-    this.itemsService.fetchItems.perform(0, false);
+    this.itemsService.fetchItems.perform(0);
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: this.filterService.asQueryParams,
     });

--- a/app/models/governing-body-classification-code.ts
+++ b/app/models/governing-body-classification-code.ts
@@ -1,7 +1,16 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany, type AsyncHasMany } from '@ember-data/model';
+
+import type GoverningBodyModel from './governing-body';
 
 export default class GoverningBodyClassificationCodeModel extends Model {
   @attr('string') declare label: string;
+
+  @hasMany('governing-body', {
+    async: false,
+    inverse: 'classification',
+    polymorphic: true,
+  })
+  declare governingBodies: AsyncHasMany<GoverningBodyModel>;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/governing-body.ts
+++ b/app/models/governing-body.ts
@@ -37,7 +37,7 @@ export default class GoverningBodyModel extends Model {
 
   @belongsTo('governing-body-classification-code', {
     async: true,
-    inverse: null,
+    inverse: 'governingBodies',
   })
   declare classification: AsyncBelongsTo<GoverningBodyClassificationCodeModel>;
 

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -35,7 +35,6 @@ export default class ApplicationRoute extends Route {
     if (transition.to?.queryParams) {
       gemeentes = transition.to?.queryParams['gemeentes'];
     }
-    this.governingBodyList.setLookupForOptions();
     this.mbpEmbed
       .setup(gemeentes)
       .then(() => this.mbpEmbed.setLoadingStateFalse());

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -10,6 +10,7 @@ import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/servic
 import type Transition from '@ember/routing/transition';
 import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
 import type GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
+import type ItemListService from 'frontend-burgernabije-besluitendatabank/services/item-list';
 
 export default class ApplicationRoute extends Route {
   @service declare plausible: PlausibleService;
@@ -18,6 +19,7 @@ export default class ApplicationRoute extends Route {
   @service declare themeList: ThemeListService;
   @service declare mbpEmbed: MbpEmbedService;
   @service declare router: Route;
+  @service('item-list') declare itemsService: ItemListService;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(args: { Args: any }) {
@@ -25,6 +27,7 @@ export default class ApplicationRoute extends Route {
 
     this.router.on('routeDidChange', (transition: Transition) => {
       this.mbpEmbed.setRouteTitle(transition);
+      this.itemsService.resetCurrentPageWhenComingBackOnOverview(transition);
     });
   }
 

--- a/app/routes/filter.ts
+++ b/app/routes/filter.ts
@@ -7,11 +7,13 @@ import type Transition from '@ember/routing/transition';
 import type DistanceListService from 'frontend-burgernabije-besluitendatabank/services/distance-list';
 import type FilterService from 'frontend-burgernabije-besluitendatabank/services/filter-service';
 import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/services/mbp-embed';
+import type GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 
 export default class FilterRoute extends Route {
   @service declare distanceList: DistanceListService;
   @service declare filterService: FilterService;
   @service declare mbpEmbed: MbpEmbedService;
+  @service declare governingBodyList: GoverningBodyListService;
 
   beforeModel() {
     this.mbpEmbed.setLoadingStateFalse();
@@ -19,6 +21,7 @@ export default class FilterRoute extends Route {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async model(params = {}, transition: Transition) {
+    this.governingBodyList.loadOptions();
     return {
       agendaStatusOptions: ['Alles', 'Behandeld', 'Niet behandeld'],
       distanceOptions: this.distanceList.getOptions(),

--- a/app/services/filter-service.ts
+++ b/app/services/filter-service.ts
@@ -79,6 +79,7 @@ export default class FilterService extends Service {
       ...params,
       governingBodyClassificationIds: deserializeArray(
         bestuursorgaanIdsAsString,
+        ',',
       ),
       themeIds: deserializeArray(themeIdsAsString),
       municipalityLabels: deserializeArray(municipalityLabelsAsString),
@@ -163,6 +164,7 @@ export default class FilterService extends Service {
     if (this.filters.governingBodyClassificationIds?.length >= 1) {
       governingBodyClassificationIds = serializeArray(
         this.filters.governingBodyClassificationIds,
+        ',',
       );
     }
     if (this.filters.themeIds?.length >= 1) {

--- a/app/services/governing-body-list.ts
+++ b/app/services/governing-body-list.ts
@@ -3,10 +3,7 @@ import Service, { service } from '@ember/service';
 import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
 import { QueryParameterKeys } from 'frontend-burgernabije-besluitendatabank/constants/query-parameter-keys';
-import {
-  deserializeArray,
-  serializeArray,
-} from 'frontend-burgernabije-besluitendatabank/utils/query-params';
+import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 
 import type Store from '@ember-data/store';
 import type RouterService from '@ember/routing/router-service';
@@ -36,36 +33,6 @@ export default class GoverningBodyListService extends Service {
   @tracked selectedIds: Array<string> = [];
   @tracked options: GoverningBodyOption[] = [];
   @tracked lookupOptions: NativeArray<GoverningBodyOption> = A([]);
-
-  /**
-   * Get the governing body classification ids from the given labels.
-   * @returns The governing body classification ids.
-   **/
-
-  async getGoverningBodyClassificationIdsFromLabels(
-    governingBodyLabels: Array<string> | string | null,
-  ): Promise<string | null> {
-    if (!governingBodyLabels) {
-      return null;
-    }
-
-    const options = await this.loadOptions();
-
-    const governingBodyLabelsArray = Array.isArray(governingBodyLabels)
-      ? governingBodyLabels
-      : deserializeArray(governingBodyLabels);
-    const governingBodyClassificationIds = options.reduce(
-      (acc, governingBody) => {
-        if (governingBodyLabelsArray.includes(governingBody.label)) {
-          acc.push(governingBody.id);
-        }
-        return acc;
-      },
-      [] as Array<string>,
-    );
-
-    return governingBodyClassificationIds.join(',');
-  }
 
   async getAll(): Promise<Array<GoverningBodyOption>> {
     const governingBodyClassifications = await this.store.query(

--- a/app/services/item-list.ts
+++ b/app/services/item-list.ts
@@ -99,6 +99,7 @@ export default class ItemListService extends Service {
 
       const governingBodyClassificationIds = serializeArray(
         this.filters.governingBodyClassificationIds,
+        ',',
       );
       let newItems: Array<AgendaItem | Session> = [];
       if (this.modelIndexToFetch === 'agenda-items') {

--- a/app/services/item-list.ts
+++ b/app/services/item-list.ts
@@ -24,6 +24,7 @@ import { createSessionsQuery } from 'frontend-burgernabije-besluitendatabank/uti
 import { serializeArray } from 'frontend-burgernabije-besluitendatabank/utils/query-params';
 import type { AgendaItemsParams } from 'frontend-burgernabije-besluitendatabank/controllers/agenda-items/types';
 import { type MuSearchResponse } from './mu-search';
+import type Transition from '@ember/routing/transition';
 
 type ModelIndex = 'agenda-items' | 'session';
 
@@ -74,6 +75,7 @@ export default class ItemListService extends Service {
 
   loadFirstPage(filters: AgendaItemsParams) {
     this.filterService.filters = filters;
+    this.currentPage = 0;
     this.fetchItems.perform(this.currentPage);
   }
 
@@ -87,6 +89,7 @@ export default class ItemListService extends Service {
     async (page: number, options: FetchItemOptions = {}) => {
       if (!this.filters) return;
 
+      this.currentPage = page;
       const { size, loadMore = false } = options;
       const locationIds = await this.fetchLocationIds();
       const themeIds = this.filterService.asQueryParams.thema;
@@ -155,6 +158,16 @@ export default class ItemListService extends Service {
       this.filters?.provinceLabels || [],
     );
     return [...municipalityIds, ...provinceIds].join(',');
+  }
+
+  resetCurrentPageWhenComingBackOnOverview(transition: Transition) {
+    const routes = ['agenda-items.index', 'sessions.index'];
+    const isGoingToOverviewPage =
+      routes.includes(transition.to?.name ?? '') &&
+      !routes.includes(transition.from?.name ?? '');
+    if (isGoingToOverviewPage) {
+      this.currentPage = 0;
+    }
   }
 }
 

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -106,7 +106,7 @@
       <Filters::SelectMultipleCheckboxFilter
         @id="governing-body"
         @label="Bestuursorganen"
-        @options={{this.bestuursorgaanOptions}}
+        @options={{this.governingBodyList.options}}
         @selected={{this.selectedBestuursorgaanIds}}
         @updateSelected={{this.updateSelectedGoverningBodyClassifications}}
         @searchField="label"

--- a/app/templates/filter.hbs
+++ b/app/templates/filter.hbs
@@ -124,7 +124,7 @@
     @loading={{this.isApplyingFilters}}
     @loadingMessage="hidden"
     @hideText={{this.isApplyingFilters}}
-    {{on "click" this.goToAgendaItems}}
+    {{on "click" this.goToOverview}}
   >
     {{this.showResultsText}}
   </AuButton>

--- a/app/utils/query-params.ts
+++ b/app/utils/query-params.ts
@@ -1,13 +1,16 @@
 const SEPARATOR = '+';
 
-export function serializeArray(array: string[]): string {
-  return array.join(SEPARATOR);
+export function serializeArray(array: string[], separator = SEPARATOR): string {
+  return array.join(separator);
 }
 
-export function deserializeArray(arrayString: string | null): string[] {
+export function deserializeArray(
+  arrayString: string | null,
+  separator = SEPARATOR,
+): string[] {
   if (!arrayString) {
     return [];
   }
 
-  return arrayString.split(SEPARATOR);
+  return arrayString.split(separator);
 }


### PR DESCRIPTION
## Description

 The bestuursorganen where not always shown as they should. We have these 2 scenarios: 
- you have selected a "lokaal bestuur" => show the classificaties for the bestuursorganen in that bestuur
- you did not select a "lokaal bestuur" => show all classificaties 

## How to test

1. Go to vlaanderen login of the app
2. Got to filters and open the bestuursorganen accordion
3. All results should be available
4. Select => deselect some of the options and look at the results
5. The count should only go up when selecting more options (or stay the same when the option has no results)
6. Show results will show the correct values + the topbar shows the correct labels for the options
7. The filters can be removed in the topbar
8. The filter page is up to date with the filters when removing

1. When going to a new page that is the overview page it should always shouw page zero
2. When clicking is a link for example zitting detail page to go to organen it should again show the page 0

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-beslist-mijn-burgerprofiel/pull/36 **EXTRA**
- https://github.com/lblod/app-burgernabije-besluitendatabank/pull/91
