### PR TITLE
bnb-984 | On screen navigation

### DIFF
--- a/app/components/session.hbs
+++ b/app/components/session.hbs
@@ -7,17 +7,23 @@
     <ul class="c-infinite-list">
       {{#each @sessionAgendaItems as |item|}}
         <li>
-          <article class="c-agenda-item-card">
+          {{! template-lint-disable no-invalid-interactive }}
+          <article
+            class="c-agenda-item-card"
+            {{on "click" (fn this.goToAgendaItem item)}}
+          >
             <AuHeading @level="1" @skin="5">
               <AuLink
-                class="c-agenda-item-card__link"
+                class="link-without-line action-sdk-color"
                 @route="agenda-items.agenda-item"
                 @model={{item.id}}
               >
                 {{item.titleFormatted}}
               </AuLink>
             </AuHeading>
-            <p class="c-agenda-item-card__content">{{item.description}}</p>
+            <p
+              class="au-u-base c-agenda-item-card__content"
+            >{{item.description}}</p>
           </article>
         </li>
       {{/each}}

--- a/app/components/session.hbs
+++ b/app/components/session.hbs
@@ -1,4 +1,4 @@
-<AuBodyContainer @scroll={{true}} id="route-session" class="au-o-region-large">
+<AuBodyContainer @scroll={{true}} id="route-session" class="au-o-region-large au-u-margin-top-large">
   <div class="au-o-layout">
     <AuHeading @level="1" class="au-u-margin-bottom">
       {{@governingBodyName}}

--- a/app/components/session.ts
+++ b/app/components/session.ts
@@ -1,0 +1,14 @@
+import { action } from '@ember/object';
+import type RouterService from '@ember/routing/router-service';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import type AgendaItemModel from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
+
+export default class Session extends Component {
+  @service declare router: RouterService;
+
+  @action
+  goToAgendaItem(item: AgendaItemModel) {
+    this.router.transitionTo('agenda-items.agenda-item', item.id);
+  }
+}

--- a/app/controllers/agenda-items/agenda-item.ts
+++ b/app/controllers/agenda-items/agenda-item.ts
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -9,10 +10,12 @@ import type { ModelFrom } from '../../lib/type-utils';
 import type ResolutionModel from 'frontend-burgernabije-besluitendatabank/models/resolution';
 import type ArrayProxy from '@ember/array/proxy';
 import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/services/mbp-embed';
+import type NavigationService from 'frontend-burgernabije-besluitendatabank/services/navigation';
 
 export default class AgendaItemController extends Controller {
   @service declare keywordStore: KeywordStoreService;
   @service declare mbpEmbed: MbpEmbedService;
+  @service declare navigation: NavigationService;
 
   declare model: ModelFrom<AgendaItemRoute>;
 
@@ -60,4 +63,9 @@ export default class AgendaItemController extends Controller {
       this.modalOpen = false;
     }
   };
+
+  @action
+  goToPreviousRoute() {
+    this.navigation.goToPreviousRoute();
+  }
 }

--- a/app/controllers/agenda-items/session.ts
+++ b/app/controllers/agenda-items/session.ts
@@ -1,10 +1,16 @@
 import Controller from '@ember/controller';
+
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
 import type { ModelFrom } from '../../lib/type-utils';
 import { sortObjectsByTitle } from 'frontend-burgernabije-besluitendatabank/utils/array-utils';
 import type AgendaItem from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
 import type AgendaItemsAgendaItemSessionRoute from 'frontend-burgernabije-besluitendatabank/routes/agenda-items/session';
+import type RouterService from '@ember/routing/router-service';
 
 export default class AgendaItemsAgendaItemSessionController extends Controller {
+  @service declare router: RouterService;
   /** Used to fetch agenda items from the model */
   declare model: ModelFrom<AgendaItemsAgendaItemSessionRoute>;
 
@@ -21,5 +27,13 @@ export default class AgendaItemsAgendaItemSessionController extends Controller {
       .slice()
       .filter(({ title }) => !!title)
       .sort(sortObjectsByTitle);
+  }
+
+  @action
+  toAgendapunt() {
+    this.router.transitionTo(
+      'agenda-items.agenda-item',
+      this.model.agendaItem.id,
+    );
   }
 }

--- a/app/controllers/agenda-items/session.ts
+++ b/app/controllers/agenda-items/session.ts
@@ -8,9 +8,11 @@ import { sortObjectsByTitle } from 'frontend-burgernabije-besluitendatabank/util
 import type AgendaItem from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
 import type AgendaItemsAgendaItemSessionRoute from 'frontend-burgernabije-besluitendatabank/routes/agenda-items/session';
 import type RouterService from '@ember/routing/router-service';
+import type NavigationService from 'frontend-burgernabije-besluitendatabank/services/navigation';
 
 export default class AgendaItemsAgendaItemSessionController extends Controller {
   @service declare router: RouterService;
+  @service declare navigation: NavigationService;
   /** Used to fetch agenda items from the model */
   declare model: ModelFrom<AgendaItemsAgendaItemSessionRoute>;
 
@@ -31,9 +33,6 @@ export default class AgendaItemsAgendaItemSessionController extends Controller {
 
   @action
   toAgendapunt() {
-    this.router.transitionTo(
-      'agenda-items.agenda-item',
-      this.model.agendaItem.id,
-    );
+    this.navigation.goToPreviousRoute();
   }
 }

--- a/app/controllers/sessions/session.ts
+++ b/app/controllers/sessions/session.ts
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -9,9 +10,11 @@ import type GoverningBodyModel from 'frontend-burgernabije-besluitendatabank/mod
 import type AgendaItemModel from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
 import type MbpEmbedService from 'frontend-burgernabije-besluitendatabank/services/mbp-embed';
 import type GoverningBodyClassificationCodeModel from 'frontend-burgernabije-besluitendatabank/models/governing-body-classification-code';
+import type NavigationService from 'frontend-burgernabije-besluitendatabank/services/navigation';
 export default class SessionsSessionController extends Controller {
   @service declare store: Store;
   @service declare mbpEmbed: MbpEmbedService;
+  @service declare navigation: NavigationService;
 
   queryParams = ['gemeentes', 'bestuursorganen'];
 
@@ -69,5 +72,10 @@ export default class SessionsSessionController extends Controller {
 
   get showMunicipality() {
     return this.mbpEmbed.isLoggedInAsVlaanderen;
+  }
+
+  @action
+  goToPreviousRoute() {
+    this.navigation.goToPreviousRoute();
   }
 }

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -11,6 +11,7 @@ import type Transition from '@ember/routing/transition';
 import type ThemeListService from 'frontend-burgernabije-besluitendatabank/services/theme-list';
 import type GoverningBodyListService from 'frontend-burgernabije-besluitendatabank/services/governing-body-list';
 import type ItemListService from 'frontend-burgernabije-besluitendatabank/services/item-list';
+import type NavigationService from 'frontend-burgernabije-besluitendatabank/services/navigation';
 
 export default class ApplicationRoute extends Route {
   @service declare plausible: PlausibleService;
@@ -19,6 +20,7 @@ export default class ApplicationRoute extends Route {
   @service declare themeList: ThemeListService;
   @service declare mbpEmbed: MbpEmbedService;
   @service declare router: Route;
+  @service declare navigation: NavigationService;
   @service('item-list') declare itemsService: ItemListService;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,6 +28,7 @@ export default class ApplicationRoute extends Route {
     super(args);
 
     this.router.on('routeDidChange', (transition: Transition) => {
+      this.navigation.onIncomingTransition(transition);
       this.mbpEmbed.setRouteTitle(transition);
       this.itemsService.resetCurrentPageWhenComingBackOnOverview(transition);
     });

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -19,7 +19,14 @@ export default class NavigationService extends Service {
 
     if (this.canGoBack && transition?.from) {
       this.transitionHistory.shift();
+      const previousUrl = window.location.href;
       window.history.back();
+      setTimeout(() => {
+        if (window.location.href === previousUrl) {
+          // nothing happened → fallback
+          this.router.transitionTo('agenda-items.index');
+        }
+      }, 200);
       return;
     }
 

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -1,0 +1,51 @@
+import Service, { service } from '@ember/service';
+
+import { tracked } from '@glimmer/tracking';
+
+import type RouterService from '@ember/routing/router-service';
+import type Transition from '@ember/routing/transition';
+
+export default class NavigationService extends Service {
+  @service declare router: RouterService;
+
+  @tracked transitionHistory: Array<Transition> = [];
+
+  onIncomingTransition(transition: Transition) {
+    this.transitionHistory.unshift(transition);
+  }
+
+  goToPreviousRoute() {
+    const transition = this.transitionHistory[0];
+
+    if (this.canGoBack && transition?.from) {
+      this.transitionHistory.shift();
+      window.history.back();
+      return;
+    }
+
+    if (this.router.currentRoute.parent) {
+      this.router.transitionTo(
+        this.router.currentRoute.parent.name + '.index',
+        this.router.currentRoute.parent.queryParams,
+      );
+    } else {
+      this.router.transitionTo('agenda-items.index');
+    }
+  }
+
+  get canGoBack() {
+    return (
+      this.transitionHistory.length >= 1 && this.transitionHistory[0]?.from
+    );
+  }
+}
+
+// Don't remove this declaration: this is what enables TypeScript to resolve
+// this service using `Owner.lookup('service:navigation')`, as well
+// as to check when you pass the service name as an argument to the decorator,
+// like `@service('navigation') declare altName: NavigationService;`.
+declare module '@ember/service' {
+  interface Registry {
+    navigation: NavigationService;
+  }
+}

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -53,6 +53,7 @@ export default class NavigationService extends Service {
       {
         ['agenda-items.index']: 'Alle agendapunten',
         ['agenda-items.agenda-item']: 'Agendapunt',
+        ['agenda-items.session']: 'Volledige agenda',
         ['sessions.index']: 'Alle zittingen',
         ['sessions.session']: 'Zitting',
       }[route.name] || 'Terug'

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -9,13 +9,43 @@ export default class NavigationService extends Service {
   @service declare router: RouterService;
 
   @tracked transition?: Transition;
+  @tracked beforeTransition?: Transition;
 
   onIncomingTransition(transition: Transition) {
+    this.beforeTransition = this.transition;
     this.transition = transition;
   }
 
   goToPreviousRoute() {
-    if (this.transition?.from) {
+    if (!this.transition) {
+      return;
+    }
+    const current = this.transition.to;
+    const previous = this.transition.from;
+
+    if (
+      previous?.name === 'agenda-items.session' &&
+      current?.name === 'agenda-items.agenda-item'
+    ) {
+      if (
+        previous.params &&
+        'id' in previous.params &&
+        previous?.name !== 'agenda-items.session'
+      ) {
+        this.router.transitionTo(
+          previous.name,
+          this.transition.to?.params['id'] as string,
+        );
+      } else {
+        if (previous.parent) {
+          this.router.transitionTo(previous.parent.name + '.index');
+        }
+      }
+
+      return;
+    }
+
+    if (previous) {
       const previousUrl = window.location.href;
       window.history.back();
       setTimeout(() => {

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -4,59 +4,74 @@ import { tracked } from '@glimmer/tracking';
 
 import type RouterService from '@ember/routing/router-service';
 import type Transition from '@ember/routing/transition';
+import type RouteInfo from '@ember/routing/route-info';
+import type { RouteInfoWithAttributes } from '@ember/routing/route-info';
 
 export default class NavigationService extends Service {
   @service declare router: RouterService;
 
-  @tracked transition?: Transition;
-  @tracked beforeTransition?: Transition;
+  @tracked history: Array<RouteInfo | RouteInfoWithAttributes> = [];
+  @tracked isNavigatingBack = false;
 
   onIncomingTransition(transition: Transition) {
-    this.beforeTransition = this.transition;
-    this.transition = transition;
+    if (this.isNavigatingBack) {
+      this.isNavigatingBack = false;
+    } else {
+      const toRoute = transition.to;
+      if (toRoute) {
+        this.history.unshift(toRoute);
+      }
+
+      if (this.history.length > 20) {
+        alert('cleanup');
+        this.history.pop(); // Cleanup
+      }
+    }
   }
 
   goToPreviousRoute() {
-    if (!this.transition) {
-      return;
-    }
-    const current = this.transition.to;
-    const previous = this.transition.from;
-
-    if (
-      previous?.name === 'agenda-items.session' &&
-      current?.name === 'agenda-items.agenda-item'
-    ) {
-      if (
-        previous.params &&
-        'id' in previous.params &&
-        previous?.name !== 'agenda-items.session'
-      ) {
-        this.router.transitionTo(
-          previous.name,
-          this.transition.to?.params['id'] as string,
-        );
-      } else {
-        if (previous.parent) {
-          this.router.transitionTo(previous.parent.name + '.index');
-        }
-      }
-
-      return;
+    if (this.history.length < 2) {
+      return this.fallbackRouteToParent();
     }
 
+    this.history.shift();
+    const previous = this.history[0];
     if (previous) {
-      const previousUrl = window.location.href;
-      window.history.back();
-      setTimeout(() => {
-        if (window.location.href === previousUrl) {
-          // nothing happened → fallback
-          this.router.transitionTo('agenda-items.index');
-        }
-      }, 200);
-      return;
+      this.isNavigatingBack = true;
+      this.transitionToRoute(previous);
+    }
+  }
+
+  get backLabel() {
+    const route = this.history[1];
+
+    if (!route) {
+      return 'Terug';
     }
 
+    return (
+      {
+        ['agenda-items.index']: 'Alle agendapunten',
+        ['agenda-items.agenda-item']: 'Agendapunt',
+        ['sessions.index']: 'Alle zittingen',
+        ['sessions.session']: 'Zitting',
+      }[route.name] || 'Terug'
+    );
+  }
+
+  transitionToRoute(route: RouteInfo | RouteInfoWithAttributes) {
+    if (route.params && 'id' in route.params) {
+      this.router.transitionTo(route.name, route?.params['id'] as string);
+    } else {
+      if (route.parent) {
+        this.router.transitionTo(route.parent.name + '.index');
+      } else {
+        this.router.transitionTo('agenda-items.index');
+      }
+    }
+  }
+
+  fallbackRouteToParent() {
     const params = this.router.currentRoute.parent?.queryParams;
     if (
       this.router.currentRoute.parent &&

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -7,6 +7,10 @@ import type Transition from '@ember/routing/transition';
 import type RouteInfo from '@ember/routing/route-info';
 import type { RouteInfoWithAttributes } from '@ember/routing/route-info';
 
+/**
+ * Please replace this service with the navigation of the embed-sdk
+ * This is not released but a WIP for the MBP development team
+ */
 export default class NavigationService extends Service {
   @service declare router: RouterService;
 
@@ -23,7 +27,6 @@ export default class NavigationService extends Service {
       }
 
       if (this.history.length > 20) {
-        alert('cleanup');
         this.history.pop(); // Cleanup
       }
     }

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -60,8 +60,12 @@ export default class NavigationService extends Service {
   }
 
   transitionToRoute(route: RouteInfo | RouteInfoWithAttributes) {
-    if (route.params && 'id' in route.params) {
-      this.router.transitionTo(route.name, route?.params['id'] as string);
+    const allowedParamKeys = ['id', 'session_id'];
+    const paramKey = route.paramNames.find((key) =>
+      allowedParamKeys.includes(key),
+    );
+    if (paramKey) {
+      this.router.transitionTo(route.name, route?.params[paramKey] as string);
     } else {
       if (route.parent) {
         this.router.transitionTo(route.parent.name + '.index');

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -8,17 +8,14 @@ import type Transition from '@ember/routing/transition';
 export default class NavigationService extends Service {
   @service declare router: RouterService;
 
-  @tracked transitionHistory: Array<Transition> = [];
+  @tracked transition?: Transition;
 
   onIncomingTransition(transition: Transition) {
-    this.transitionHistory.unshift(transition);
+    this.transition = transition;
   }
 
   goToPreviousRoute() {
-    const transition = this.transitionHistory[0];
-
-    if (this.canGoBack && transition?.from) {
-      this.transitionHistory.shift();
+    if (this.transition?.from) {
       const previousUrl = window.location.href;
       window.history.back();
       setTimeout(() => {
@@ -43,12 +40,6 @@ export default class NavigationService extends Service {
     } else {
       this.router.transitionTo('agenda-items.index');
     }
-  }
-
-  get canGoBack() {
-    return (
-      this.transitionHistory.length >= 1 && this.transitionHistory[0]?.from
-    );
   }
 }
 

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -30,10 +30,15 @@ export default class NavigationService extends Service {
       return;
     }
 
-    if (this.router.currentRoute.parent) {
+    const params = this.router.currentRoute.parent?.queryParams;
+    if (
+      this.router.currentRoute.parent &&
+      params &&
+      Object.keys(params).length >= 1
+    ) {
       this.router.transitionTo(
         this.router.currentRoute.parent.name + '.index',
-        this.router.currentRoute.parent.queryParams,
+        params,
       );
     } else {
       this.router.transitionTo('agenda-items.index');

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -1,8 +1,16 @@
 {{page-title this.model.agendaItem.titleFormatted}}
 <AuModalContainer />
-
 <div id="route-detail">
-  <div class="au-u-flex au-u-flex--column">
+  <AuToolbar @border="bottom" class="sticky-top" as |Group|>
+    <Group>
+      <AuButton
+        class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
+        @skin="link"
+        {{on "click" this.goToPreviousRoute}}
+      >Terug</AuButton>
+    </Group>
+  </AuToolbar>
+  <div class="au-u-flex au-u-flex--column au-u-margin-top-large">
     <AuHeading @level="1" @skin="3" class="au-o-box au-u-padding-right-small">
       {{this.model.agendaItem.titleFormatted}}
     </AuHeading>

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -4,6 +4,7 @@
   <AuToolbar @border="bottom" class="sticky-top" as |Group|>
     <Group>
       <AuButton
+        @icon="chevron-left"
         class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
         @skin="link"
         {{on "click" this.goToPreviousRoute}}

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -7,7 +7,7 @@
         class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
         @skin="link"
         {{on "click" this.goToPreviousRoute}}
-      >Terug</AuButton>
+      >{{this.navigation.backLabel}}</AuButton>
     </Group>
   </AuToolbar>
   <div class="au-u-flex au-u-flex--column au-u-margin-top-large">

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -3,6 +3,7 @@
 <AuToolbar @border="bottom" class="sticky-top" as |Group|>
   <Group>
     <AuButton
+      @icon="chevron-left"
       class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
       @skin="link"
       {{on "click" this.toAgendapunt}}

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -6,7 +6,7 @@
       class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
       @skin="link"
       {{on "click" this.toAgendapunt}}
-    >Terug</AuButton>
+    >Terug naar agendapunt</AuButton>
   </Group>
 </AuToolbar>
 

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -6,7 +6,7 @@
       class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
       @skin="link"
       {{on "click" this.toAgendapunt}}
-    >Terug naar agendapunt</AuButton>
+    >{{this.navigation.backLabel}}</AuButton>
   </Group>
 </AuToolbar>
 

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -1,14 +1,12 @@
 {{page-title "Zitting"}}
 
-<AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+<AuToolbar @border="bottom" class="sticky-top" as |Group|>
   <Group>
-    <ul class="au-c-list-horizontal au-c-list-horizontal--small">
-      <li class="au-c-list-horizontal__item">
-        <AuLink @route="agenda-items.agenda-item" @model={{this.model.agendaItem.id}} @icon="arrow-left">
-          Terug naar agendapunt
-        </AuLink>
-      </li>
-    </ul>
+    <AuButton
+      class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
+      @skin="link"
+      {{on "click" this.toAgendapunt}}
+    >Terug</AuButton>
   </Group>
 </AuToolbar>
 

--- a/app/templates/sessions/session.hbs
+++ b/app/templates/sessions/session.hbs
@@ -1,8 +1,17 @@
 {{page-title "Zitting"}}
-
 <AuModalContainer />
+
 <div id="route-detail">
-  <div class="au-u-flex au-u-flex--column">
+  <AuToolbar @border="bottom" class="sticky-top" as |Group|>
+    <Group>
+      <AuButton
+        class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
+        @skin="link"
+        {{on "click" this.goToPreviousRoute}}
+      >Terug</AuButton>
+    </Group>
+  </AuToolbar>
+  <div class="au-u-flex au-u-flex--column au-u-margin-top-large">
     <AuHeading @level="1" @skin="3" class="au-o-box au-u-padding-right-small">
       {{@model.session.titleFormatted}}
     </AuHeading>

--- a/app/templates/sessions/session.hbs
+++ b/app/templates/sessions/session.hbs
@@ -8,7 +8,7 @@
         class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
         @skin="link"
         {{on "click" this.goToPreviousRoute}}
-      >Terug</AuButton>
+      >{{this.navigation.backLabel}}</AuButton>
     </Group>
   </AuToolbar>
   <div class="au-u-flex au-u-flex--column au-u-margin-top-large">

--- a/app/templates/sessions/session.hbs
+++ b/app/templates/sessions/session.hbs
@@ -5,6 +5,7 @@
   <AuToolbar @border="bottom" class="sticky-top" as |Group|>
     <Group>
       <AuButton
+        @icon="chevron-left"
         class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
         @skin="link"
         {{on "click" this.goToPreviousRoute}}


### PR DESCRIPTION
## Description

The sdk does not support clearing the embed layers. This makes it hard to reset and show everything again from the overview list of our app. We do want the user to navigate back so we will be adding on screen buttons for that to the detail pages of our app (agendapunt and zitting).

## How to test

1. Open the app and navigate back with system navigation, a popup should show
2. Go back to lokaalbeslist app and navigat two or 3 agendapunten deep, a back button should be visible once the detail page is shown.
3. Going back will show the previous detail page until on the overview screen

## Links to other PR's

- Original sdk navaigation PR https://github.com/lblod/frontend-lokaal-beslist-mijn-burgerprofiel/pull/32
