### PR TITLE
bnb-980 | Design volledige agenda pagina

### DIFF
--- a/app/components/session.hbs
+++ b/app/components/session.hbs
@@ -7,17 +7,23 @@
     <ul class="c-infinite-list">
       {{#each @sessionAgendaItems as |item|}}
         <li>
-          <article class="c-agenda-item-card">
+          {{! template-lint-disable no-invalid-interactive }}
+          <article
+            class="c-agenda-item-card"
+            {{on "click" (fn this.goToAgendaItem item)}}
+          >
             <AuHeading @level="1" @skin="5">
               <AuLink
-                class="c-agenda-item-card__link"
+                class="link-without-line action-sdk-color"
                 @route="agenda-items.agenda-item"
                 @model={{item.id}}
               >
                 {{item.titleFormatted}}
               </AuLink>
             </AuHeading>
-            <p class="c-agenda-item-card__content">{{item.description}}</p>
+            <p
+              class="au-u-base c-agenda-item-card__content"
+            >{{item.description}}</p>
           </article>
         </li>
       {{/each}}

--- a/app/components/session.hbs
+++ b/app/components/session.hbs
@@ -1,4 +1,4 @@
-<AuBodyContainer @scroll={{true}} id="route-session" class="au-o-region-large">
+<AuBodyContainer @scroll={{true}} id="route-session" class="au-o-region-large au-u-margin-top-large">
   <div class="au-o-layout">
     <AuHeading @level="1" class="au-u-margin-bottom">
       {{@governingBodyName}}

--- a/app/components/session.ts
+++ b/app/components/session.ts
@@ -1,0 +1,14 @@
+import { action } from '@ember/object';
+import type RouterService from '@ember/routing/router-service';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import type AgendaItemModel from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
+
+export default class Session extends Component {
+  @service declare router: RouterService;
+
+  @action
+  goToAgendaItem(item: AgendaItemModel) {
+    this.router.transitionTo('agenda-items.agenda-item', item.id);
+  }
+}

--- a/app/controllers/agenda-items/session.ts
+++ b/app/controllers/agenda-items/session.ts
@@ -1,10 +1,16 @@
 import Controller from '@ember/controller';
+
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
 import type { ModelFrom } from '../../lib/type-utils';
 import { sortObjectsByTitle } from 'frontend-burgernabije-besluitendatabank/utils/array-utils';
 import type AgendaItem from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
 import type AgendaItemsAgendaItemSessionRoute from 'frontend-burgernabije-besluitendatabank/routes/agenda-items/session';
+import type RouterService from '@ember/routing/router-service';
 
 export default class AgendaItemsAgendaItemSessionController extends Controller {
+  @service declare router: RouterService;
   /** Used to fetch agenda items from the model */
   declare model: ModelFrom<AgendaItemsAgendaItemSessionRoute>;
 
@@ -21,5 +27,13 @@ export default class AgendaItemsAgendaItemSessionController extends Controller {
       .slice()
       .filter(({ title }) => !!title)
       .sort(sortObjectsByTitle);
+  }
+
+  @action
+  toAgendapunt() {
+    this.router.transitionTo(
+      'agenda-items.agenda-item',
+      this.model.agendaItem.id,
+    );
   }
 }

--- a/app/controllers/agenda-items/session.ts
+++ b/app/controllers/agenda-items/session.ts
@@ -8,9 +8,11 @@ import { sortObjectsByTitle } from 'frontend-burgernabije-besluitendatabank/util
 import type AgendaItem from 'frontend-burgernabije-besluitendatabank/models/agenda-item';
 import type AgendaItemsAgendaItemSessionRoute from 'frontend-burgernabije-besluitendatabank/routes/agenda-items/session';
 import type RouterService from '@ember/routing/router-service';
+import type NavigationService from 'frontend-burgernabije-besluitendatabank/services/navigation';
 
 export default class AgendaItemsAgendaItemSessionController extends Controller {
   @service declare router: RouterService;
+  @service declare navigation: NavigationService;
   /** Used to fetch agenda items from the model */
   declare model: ModelFrom<AgendaItemsAgendaItemSessionRoute>;
 
@@ -31,9 +33,6 @@ export default class AgendaItemsAgendaItemSessionController extends Controller {
 
   @action
   toAgendapunt() {
-    this.router.transitionTo(
-      'agenda-items.agenda-item',
-      this.model.agendaItem.id,
-    );
+    this.navigation.goToPreviousRoute();
   }
 }

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -53,6 +53,7 @@ export default class NavigationService extends Service {
       {
         ['agenda-items.index']: 'Alle agendapunten',
         ['agenda-items.agenda-item']: 'Agendapunt',
+        ['agenda-items.session']: 'Volledige agenda',
         ['sessions.index']: 'Alle zittingen',
         ['sessions.session']: 'Zitting',
       }[route.name] || 'Terug'

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -7,6 +7,10 @@ import type Transition from '@ember/routing/transition';
 import type RouteInfo from '@ember/routing/route-info';
 import type { RouteInfoWithAttributes } from '@ember/routing/route-info';
 
+/**
+ * Please replace this service with the navigation of the embed-sdk
+ * This is not released but a WIP for the MBP development team
+ */
 export default class NavigationService extends Service {
   @service declare router: RouterService;
 
@@ -23,7 +27,6 @@ export default class NavigationService extends Service {
       }
 
       if (this.history.length > 20) {
-        alert('cleanup');
         this.history.pop(); // Cleanup
       }
     }

--- a/app/templates/agenda-items/agenda-item.hbs
+++ b/app/templates/agenda-items/agenda-item.hbs
@@ -4,6 +4,7 @@
   <AuToolbar @border="bottom" class="sticky-top" as |Group|>
     <Group>
       <AuButton
+        @icon="chevron-left"
         class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
         @skin="link"
         {{on "click" this.goToPreviousRoute}}

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -3,6 +3,7 @@
 <AuToolbar @border="bottom" class="sticky-top" as |Group|>
   <Group>
     <AuButton
+      @icon="chevron-left"
       class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
       @skin="link"
       {{on "click" this.toAgendapunt}}

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -6,7 +6,7 @@
       class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
       @skin="link"
       {{on "click" this.toAgendapunt}}
-    >Terug</AuButton>
+    >Terug naar agendapunt</AuButton>
   </Group>
 </AuToolbar>
 

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -6,7 +6,7 @@
       class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
       @skin="link"
       {{on "click" this.toAgendapunt}}
-    >Terug naar agendapunt</AuButton>
+    >{{this.navigation.backLabel}}</AuButton>
   </Group>
 </AuToolbar>
 

--- a/app/templates/agenda-items/session.hbs
+++ b/app/templates/agenda-items/session.hbs
@@ -1,14 +1,12 @@
 {{page-title "Zitting"}}
 
-<AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+<AuToolbar @border="bottom" class="sticky-top" as |Group|>
   <Group>
-    <ul class="au-c-list-horizontal au-c-list-horizontal--small">
-      <li class="au-c-list-horizontal__item">
-        <AuLink @route="agenda-items.agenda-item" @model={{this.model.agendaItem.id}} @icon="arrow-left">
-          Terug naar agendapunt
-        </AuLink>
-      </li>
-    </ul>
+    <AuButton
+      class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
+      @skin="link"
+      {{on "click" this.toAgendapunt}}
+    >Terug</AuButton>
   </Group>
 </AuToolbar>
 

--- a/app/templates/sessions/session.hbs
+++ b/app/templates/sessions/session.hbs
@@ -5,6 +5,7 @@
   <AuToolbar @border="bottom" class="sticky-top" as |Group|>
     <Group>
       <AuButton
+        @icon="chevron-left"
         class="au-u-padding au-u-padding-bottom-small link-without-line action-sdk-color"
         @skin="link"
         {{on "click" this.goToPreviousRoute}}


### PR DESCRIPTION
## Description

When clicking in the detail page to volledige agenda the design is not as in the rest of the app.

## How to test

1. Got to an agendapunt its detail info
2. Click the volledige agenda link
3. It should look the same as the infinite list

## Attachements

**Previous**
<img width="1481" height="658" alt="image" src="https://github.com/user-attachments/assets/273c21e1-0556-4add-88b5-ab14d95291ad" />

**Now**
<img width="1232" height="484" alt="image" src="https://github.com/user-attachments/assets/91e78171-3214-40b0-b262-29e9bfbfd2af" />

